### PR TITLE
Resolve images with relative paths for their src

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -42,7 +42,7 @@ class MarkdownPreviewView extends ScrollView
         if error
           @showError(error)
         else
-          @html(@tokenizeCodeBlocks(html))
+          @html(@tokenizeCodeBlocks(@resolveImagePaths(html)))
 
   getTitle: ->
     "#{path.basename(@getPath())} Preview"
@@ -63,6 +63,18 @@ class MarkdownPreviewView extends ScrollView
   showLoading: ->
     @html $$$ ->
       @div class: 'markdown-spinner', 'Loading Markdown...'
+
+  resolveImagePaths: (html) =>
+    html = $(html)
+    imgList = html.find("img")
+
+    for imgElement in imgList
+      img = $(imgElement)
+      src = img.attr('src')
+      continue if src.match /^(https?:\/\/)/
+      img.attr('src', path.resolve(path.dirname(@getPath()), src))
+
+    html
 
   tokenizeCodeBlocks: (html) =>
     html = $(html)

--- a/spec/fixtures/subdir/file.markdown
+++ b/spec/fixtures/subdir/file.markdown
@@ -18,3 +18,9 @@ function f(x) {
 drink-that-stuff:
   tastes-weird~
 ```
+
+![Image1](image1.png)
+
+![Image2](/tmp/image2.png)
+
+![Image3](http://github.com/image3.png)

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -41,7 +41,7 @@ describe "Markdown preview package", ->
       atom.workspaceView.attachToDom()
 
       waitsForPromise ->
-        atom.workspaceView.open("file.markdown")
+        atom.workspaceView.open("subdir/file.markdown")
 
     it "splits the current pane to the right with a markdown preview for the file", ->
       [editorPane, previewPane] = []
@@ -68,7 +68,7 @@ describe "Markdown preview package", ->
       atom.workspaceView.attachToDom()
 
       waitsForPromise ->
-        atom.workspaceView.open("file.markdown")
+        atom.workspaceView.open("subdir/file.markdown")
 
       runs ->
         atom.workspaceView.getActiveView().trigger 'markdown-preview:show'

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -5,7 +5,7 @@ describe "MarkdownPreviewView", ->
   [file, preview] = []
 
   beforeEach ->
-    filePath = atom.project.resolve('file.markdown')
+    filePath = atom.project.resolve('subdir/file.markdown')
     preview = new MarkdownPreviewView(filePath)
 
     waitsForPromise ->
@@ -52,3 +52,23 @@ describe "MarkdownPreviewView", ->
       it "does not tokenize the code block", ->
         expect(preview.find("pre code:not([class])").children().length).toBe 0
         expect(preview.find("pre code.lang-kombucha").children().length).toBe 0
+
+  describe "image resolving", ->
+    beforeEach ->
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+    describe "when the image uses a relative path", ->
+      it "resolves to a path relative to the file", ->
+        image = preview.find("img[alt=Image1]")
+        expect(image.attr('src')).toBe atom.project.resolve('subdir/image1.png')
+
+    describe "when the image uses an absolute path", ->
+      it "doesn't change the path", ->
+        image = preview.find("img[alt=Image2]")
+        expect(image.attr('src')).toBe '/tmp/image2.png'
+
+    describe "when the image uses a web URL", ->
+      it "doesn't change the URL", ->
+        image = preview.find("img[alt=Image3]")
+        expect(image.attr('src')).toBe 'http://github.com/image3.png'


### PR DESCRIPTION
I was working on a readme with an image in it today, and notice that it wasn't rendering correctly as it used a relative path (which is supported on GitHub). This PR adds that capability.

I moved the fixture markdown file into a new subdirectory in order to test proper resolving of the image relative to the directory the markdown file is contained within instead of the project root (which were the same without such a change).

![SS](https://www.evernote.com/shard/s23/sh/973575b5-eb8d-4085-bac8-237879554c44/bccfa0620fdde72dce805c250a422c50/deep/0/Fullscreen-2-16-14-7-48-PM.png)
