### PR TITLE
fix keybinding used in settings pane description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-preview",
   "version": "0.37.0",
   "main": "./lib/markdown-preview",
-  "description": "Open a rendered version of the Markdown in the current editor with `ctrl-m`.",
+  "description": "Open a rendered version of the Markdown in the current editor with `ctrl-shift-m`.",
   "repository": "https://github.com/atom/markdown-preview",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
was going through the Atom.io settings and came across the Markdown Preview package, but `ctrl`+`m` wasn't working.
