### PR TITLE
Support more lang / extension types

### DIFF
--- a/lib/extension-helper.coffee
+++ b/lib/extension-helper.coffee
@@ -11,6 +11,8 @@ extensionsByFenceName =
   'json': 'json'
   'less': 'less'
   'mustache': 'mustache'
+  'objc': 'm'
+  'objective-c': 'm'
   'python': 'py'
   'rb': 'rb'
   'ruby': 'rb'


### PR DESCRIPTION
Maybe there is a more automated way to make sure the markdown parser can handle all the languages that are installed. Wonder if the language packages could define their 'fence names'. Not sure. At the very least there should be a list of these somewhere. Maybe in the github repo? I cant find a list of these anywhere. 

I've added an entry for objective-c.
