### PR TITLE
Add ability to use HTML tags in Markdown documents

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -40,8 +40,7 @@ class MarkdownPreviewView extends ScrollView
     @showLoading()
     @file.read().then (contents) =>
       roaster = require 'roaster'
-      sanitize = true
-      roaster contents, {sanitize}, (error, html) =>
+      roaster contents, {}, (error, html) =>
         if error
           @showError(error)
         else

--- a/spec/fixtures/subdir/file.markdown
+++ b/spec/fixtures/subdir/file.markdown
@@ -24,3 +24,5 @@ drink-that-stuff:
 ![Image2](/tmp/image2.png)
 
 ![Image3](http://github.com/image3.png)
+
+HTML code is <u>valid</u> in GFM

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -53,6 +53,15 @@ describe "MarkdownPreviewView", ->
         expect(preview.find("pre code:not([class])").children().length).toBe 0
         expect(preview.find("pre code.lang-kombucha").children().length).toBe 0
 
+  describe "html markup", ->
+    beforeEach ->
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+    describe "when the document contains an <u> tag", ->
+      it "doesn't escape the tag", ->
+        expect(preview.find("u")).toExist()
+
   describe "image resolving", ->
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
The original Markdown specification by [John Gruber suggests using plain HTML](http://daringfireball.net/projects/markdown/syntax#html) for
tables and other advances things. GFM doesn't document the use of HTML but
it is supported and correctly rendered almost everywhere on GitHub (Issues, README.md, etc.)

Because of this, `markdown-preview` should support the use of HTML too,
otherwise it wouldn't be a Markdown preview tool.
