### PR TITLE
Don't wrap code blocks

### DIFF
--- a/stylesheets/markdown-preview.less
+++ b/stylesheets/markdown-preview.less
@@ -396,6 +396,7 @@
     white-space: pre;
     border: none;
     background: transparent;
+    word-wrap: normal;
   }
 
   pre {


### PR DESCRIPTION
Fixes https://github.com/atom/markdown-preview/issues/44

This changes the wrapping behavior so that code blocks are **not** wrapped (which matches the behavior on github.com).

**Before:**

![screen shot 2014-03-13 at 7 37 18 pm](https://f.cloud.github.com/assets/38924/2413511/276891e2-aadf-11e3-8cc1-1b37b88dc717.png)

**After:**

![screen shot 2014-03-13 at 7 37 53 pm](https://f.cloud.github.com/assets/38924/2413514/2f3cb25e-aadf-11e3-8228-f169101eef60.png)

cc @kevinsawicki
