### PR TITLE
Add `markdown-changed` emit event

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -101,7 +101,7 @@ class MarkdownPreviewView extends ScrollView
         @showError(error)
       else
         @html(@tokenizeCodeBlocks(@resolveImagePaths(html)))
-        @emit('markdown-changed')
+        @trigger('markdown-preview:markdown-changed')
 
   getTitle: ->
     if @file?


### PR DESCRIPTION
This event is helpful for packages that wish to extend the default Markdown previewer via `roaster`.

For example, some MD implementations use the following notation for definition lists:

```
term
: definition
: another definition

another term
and another term
: and a definition for the term
```

A second package could list for the event, then update the contents of the preview window.

/cc @kevinsawicki 
