### PR TITLE
Call marked with sanitize: false

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -103,7 +103,7 @@ class MarkdownPreviewView extends ScrollView
 
   renderMarkdownText: (text) ->
     roaster = require 'roaster'
-    sanitize = true
+    sanitize = false
     breaks = atom.config.get('markdown-preview.breakOnSingleNewline')
     roaster text, {sanitize, breaks}, (error, html) =>
       if error


### PR DESCRIPTION
The author can be presumed trustworthy in the context of their own text editor so sanitisation is redundant and detracts from usability
