### PR TITLE
Ensure bullet aligns with first checkbox item

### DIFF
--- a/stylesheets/markdown-preview.less
+++ b/stylesheets/markdown-preview.less
@@ -197,6 +197,10 @@
     li ul:first-of-type {
       margin-top: 0;
     }
+
+    li > :first-child {
+      vertical-align: top;
+    }
   }
 
   ul ul,


### PR DESCRIPTION
Ran into some strange rendering in the preview window when working with bulleted lists and GFM checkboxes.

![bug](https://cloud.githubusercontent.com/assets/1041456/2685064/4e6a0dde-c1c3-11e3-8ea9-5f23823b1740.jpg)

On the left is the raw markdown and on the right is the rendered view.

The bullet doesn't align with the checkbox list item that it belongs to, and instead appears to apply to the entire block, ie. the list item and all of its children.

Identified as a problem upstream with [roaster](https://github.com/gjtorikian/roaster) and subsequently how it builds checkboxes with [task-list-js](https://github.com/gjtorikian/task-lists-js).  Opened gjtorikian/task-lists-js#3 for a permanent solution, but the tweak below works well enough in the interim.
