### PR TITLE
Add support for C# and Erlang in fenced code blocks

### DIFF
--- a/lib/extension-helper.coffee
+++ b/lib/extension-helper.coffee
@@ -18,6 +18,7 @@ extensionsByFenceName =
   'objc': 'm'
   'objective-c': 'm'
   'php': 'php'
+  'py': 'py'
   'python': 'py'
   'rb': 'rb'
   'ruby': 'rb'


### PR DESCRIPTION
A companion to https://github.com/atom/language-gfm/pull/25, this addresses https://github.com/atom/markdown-preview/issues/79, and https://github.com/atom/language-gfm/issues/23. 

BEFORE 

![screen shot 2014-05-10 at 6 53 53 pm](https://cloud.githubusercontent.com/assets/38924/2936700/1a8f93a2-d86c-11e3-9a40-1de3d90e0ba7.png)

AFTER

![screen shot 2014-05-10 at 3 59 46 pm](https://cloud.githubusercontent.com/assets/38924/2936696/da2e088e-d86b-11e3-9b70-8a9869b4e98d.png)

Note: this pull request adds highlighting for fenced code blocks in the Markdown preview only, not in the editor.
