### PR TITLE
Support preview toggle when focus is on editor

### DIFF
--- a/keymaps/markdown-preview.cson
+++ b/keymaps/markdown-preview.cson
@@ -1,4 +1,4 @@
-'.workspace .editor':
+'.workspace, .workspace .editor':
   'ctrl-M': 'markdown-preview:toggle'
 
 '.platform-darwin .markdown-preview':


### PR DESCRIPTION
This pull request allows the user to toggle the markdown preview while the focus is in the editor as well as in the workspace.
