### PR TITLE
Resolve images w/ absolute src paths to use the path from project root

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -74,7 +74,10 @@ resolveImagePaths = (html, filePath) ->
     img = $(imgElement)
     if src = img.attr('src')
       continue if src.match /^(https?:\/\/)/
-      img.attr('src', path.resolve(path.dirname(filePath), src))
+      if src[0] is '/'
+        img.attr('src', atom.project.resolve(src.substring(1)))
+      else
+        img.attr('src', path.resolve(path.dirname(filePath), src))
 
   html
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -100,9 +100,9 @@ describe "MarkdownPreviewView", ->
         expect(image.attr('src')).toBe atom.project.resolve('subdir/image1.png')
 
     describe "when the image uses an absolute path", ->
-      it "doesn't change the path", ->
+      it "resolves to a path relative to the project root", ->
         image = preview.find("img[alt=Image2]")
-        expect(image.attr('src')).toBe path.normalize(path.resolve('/tmp/image2.png'))
+        expect(image.attr('src')).toBe atom.project.resolve('tmp/image2.png')
 
     describe "when the image uses a web URL", ->
       it "doesn't change the URL", ->


### PR DESCRIPTION
This is a follow-up to changes made by @BinaryMuse and accepted by @probablycorey on #12, which made relative image URLs work on preview. I modified it slightly so that the absolute image URLs to resolve to the path from the project root.
### Before

`![](/images/test.jpg)` resolved to `/images/test.jpg`, because `path.resolve(..., "/absolute-path")` returns `/absolute-path`.

This is pretty useless in my opinion.
### After

If the current project directory is `/Users/shu/blog`, then `![](/images/test.jpg)` would resolve to `/Users/shu/blog/images/test.jpg`.

I think `absolute URL == from project root` makes more sense than `absolute URL == from filesystem root`, at least for displaying image previews.
### Use Case

This has been useful for me when I'm writing [Jekyll](http://jekyllrb.com/), because:
- My markdown files live in `category-name/_posts/*.md`
- My images live in `images/*.jpg`
- Jekyll serves my posts at `http://localhost:4000/<permalink>` and images at `http://localhost:4000/images/*.jpg`, so I'd use absolute image URLs in my markdown files, which wouldn't render currently. Relative URLs won't work b/c paths don't match.
