### PR TITLE
Use text editors for code blocks

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -120,7 +120,7 @@ module.exports =
 
     renderer ?= require './renderer'
     text = editor.getSelectedText() or editor.getText()
-    renderer.toText text, editor.getPath(), editor.getGrammar(), (error, html) =>
+    renderer.toHTML text, editor.getPath(), editor.getGrammar(), (error, html) =>
       if error
         console.warn('Copying Markdown as HTML failed', error)
       else

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -136,14 +136,13 @@ class MarkdownPreviewView extends ScrollView
       @renderMarkdownText(@editor.getText())
 
   renderMarkdownText: (text) ->
-    renderer.toHtml text, @getPath(), @getGrammar(), (error, html) =>
+    renderer.toDOMFragment text, @getPath(), @getGrammar(), (error, domFragment) =>
       if error
         @showError(error)
       else
         @loading = false
         @empty()
-        console.log html
-        @append(html)
+        @append(domFragment)
         @emitter.emit 'did-change-markdown'
         @originalTrigger('markdown-preview:markdown-changed')
 

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -141,7 +141,9 @@ class MarkdownPreviewView extends ScrollView
         @showError(error)
       else
         @loading = false
-        @html(html)
+        @empty()
+        console.log html
+        @append(html)
         @emitter.emit 'did-change-markdown'
         @originalTrigger('markdown-preview:markdown-changed')
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -12,6 +12,27 @@ highlighter = null
 packagePath = path.dirname(__dirname)
 
 exports.toDOMFragment = (text='', filePath, grammar, callback) ->
+  render text, filePath, grammar, (error, html) ->
+    return callback(error) if error?
+
+    template = document.createElement('template')
+    template.innerHTML = html
+    domFragment = template.content.cloneNode(true)
+
+    # Default code blocks to be coffee in Literate CoffeeScript files
+    defaultCodeLanguage = 'coffee' if grammar?.scopeName is 'source.litcoffee'
+    convertCodeBlocksToAtomEditors(domFragment, defaultCodeLanguage)
+    callback(null, domFragment)
+
+exports.toHTML = (text='', filePath, grammar, callback) ->
+  render text, filePath, grammar, (error, html) ->
+    return callback(error) if error?
+    # Default code blocks to be coffee in Literate CoffeeScript files
+    defaultCodeLanguage = 'coffee' if grammar?.scopeName is 'source.litcoffee'
+    html = tokenizeCodeBlocks(html, defaultCodeLanguage)
+    callback(null, html)
+
+render = (text, filePath, grammar, callback) ->
   roaster ?= require 'roaster'
   options =
     sanitize: false
@@ -24,25 +45,12 @@ exports.toDOMFragment = (text='', filePath, grammar, callback) ->
   roaster text, options, (error, html) =>
     return callback(error) if error
 
-    grammar ?= atom.grammars.selectGrammar(filePath, text)
-    # Default code blocks to be coffee in Literate CoffeeScript files
-    defaultCodeLanguage = 'coffee' if grammar.scopeName is 'source.litcoffee'
-
     html = sanitize(html)
     html = resolveImagePaths(html, filePath)
-    html = tokenizeCodeBlocks(html, defaultCodeLanguage)
-    callback(null, html)
-
-exports.toHTML = (text, filePath, grammar, callback) ->
-  exports.toHtml text, filePath, grammar, (error, html) ->
-    if error
-      callback(error)
-    else
-      string = $(document.createElement('div')).append(html)[0].innerHTML
-      callback(error, string)
+    callback(null, html.trim())
 
 sanitize = (html) ->
-  o = cheerio.load("<div>#{html}</div>")
+  o = cheerio.load(html)
   o('script').remove()
   attributesToRemove = [
     'onabort'
@@ -72,9 +80,9 @@ sanitize = (html) ->
   o.html()
 
 resolveImagePaths = (html, filePath) ->
-  html = $(html)
-  for imgElement in html.find('img')
-    img = $(imgElement)
+  o = cheerio.load(html)
+  for imgElement in o('img')
+    img = o(imgElement)
     if src = img.attr('src')
       continue if src.match(/^(https?|atom):\/\//)
       continue if src.startsWith(process.resourcesPath)
@@ -87,29 +95,51 @@ resolveImagePaths = (html, filePath) ->
       else
         img.attr('src', path.resolve(path.dirname(filePath), src))
 
-  html
+  o.html()
 
-tokenizeCodeBlocks = (html, defaultLanguage='text') ->
-  html = $(html)
-
+convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
   if fontFamily = atom.config.get('editor.fontFamily')
-    $(html).find('code').css('font-family', fontFamily)
 
-  for preElement in $.merge(html.filter("pre"), html.find("pre"))
-    codeBlock = $(preElement.firstChild)
-    fenceName = codeBlock.attr('class')?.replace(/^lang-/, '') ? defaultLanguage
+    for codeElement in domFragment.querySelectorAll('code')
+      codeElement.style.fontFamily = fontFamily
+
+  for preElement in domFragment.querySelectorAll('pre')
+    codeBlock = preElement.firstChild
+    fenceName = codeBlock.getAttribute('class')?.replace(/^lang-/, '') ? defaultLanguage
 
     editorElement = document.createElement('atom-text-editor')
     editorElement.setAttributeNode(document.createAttribute('gutter-hidden'))
     editorElement.removeAttribute('tabindex') # make read-only
 
-    $(editorElement).insertAfter(preElement)
+    preElement.parentNode.insertBefore(editorElement, preElement)
+    preElement.remove()
 
     editor = editorElement.getModel()
-    editor.setText(codeBlock.text().trim())
+    editor.setText(codeBlock.textContent.trim())
     if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
       editor.setGrammar(grammar)
 
-    preElement.remove()
+  domFragment
 
-  html
+tokenizeCodeBlocks = (html, defaultLanguage='text') ->
+  o = cheerio.load(html)
+
+  if fontFamily = atom.config.get('editor.fontFamily')
+    o('code').css('font-family', fontFamily)
+
+  for preElement in o("pre")
+    codeBlock = o(preElement).children().first()
+    fenceName = codeBlock.attr('class')?.replace(/^lang-/, '') ? defaultLanguage
+
+    highlighter ?= new Highlights(registry: atom.grammars)
+    highlightedHtml = highlighter.highlightSync
+      fileContents: codeBlock.text()
+      scopeName: scopeForFenceName(fenceName)
+
+    highlightedBlock = o(highlightedHtml)
+    # The `editor` class messes things up as `.editor` has absolutely positioned lines
+    highlightedBlock.removeClass('editor').addClass("lang-#{fenceName}")
+
+    o(preElement).replaceWith(highlightedBlock)
+
+  o.html()

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -11,7 +11,7 @@ highlighter = null
 {resourcePath} = atom.getLoadSettings()
 packagePath = path.dirname(__dirname)
 
-exports.toHtml = (text='', filePath, grammar, callback) ->
+exports.toDOMFragment = (text='', filePath, grammar, callback) ->
   roaster ?= require 'roaster'
   options =
     sanitize: false
@@ -33,7 +33,7 @@ exports.toHtml = (text='', filePath, grammar, callback) ->
     html = tokenizeCodeBlocks(html, defaultCodeLanguage)
     callback(null, html)
 
-exports.toText = (text, filePath, grammar, callback) ->
+exports.toHTML = (text, filePath, grammar, callback) ->
   exports.toHtml text, filePath, grammar, (error, html) ->
     if error
       callback(error)

--- a/stylesheets/markdown-preview.less
+++ b/stylesheets/markdown-preview.less
@@ -29,9 +29,9 @@
 // container with .markdown-preview on it should render generally well. It also
 // includes some GitHub Flavored Markdown specific styling (like @mentions)
 .markdown-preview {
-  pre,
   code,
-  tt {
+  tt,
+  atom-text-editor {
     font-size: 12px;
     font-family: Consolas, "Liberation Mono", Courier, monospace;
   }
@@ -46,6 +46,16 @@
 
   ul > li {
     list-style-type: disc;
+  }
+
+  li > atom-text-editor {
+    display: inline-block;
+    vertical-align: top;
+    width: 100%;
+  }
+
+  li:last-child > atom-text-editor {
+    margin-bottom: 0;
   }
 
   & > *:first-child {
@@ -136,7 +146,7 @@
   blockquote,
   ul, ol, dl,
   table,
-  pre {
+  atom-text-editor {
     margin: 15px 0;
   }
 
@@ -390,17 +400,7 @@
 
   code { white-space: nowrap; }
 
-  // Code tags within code blocks (<pre>s)
-  pre > code {
-    margin: 0;
-    padding: 0;
-    white-space: pre;
-    border: none;
-    background: transparent;
-    word-wrap: normal;
-  }
-
-  pre {
+  atom-text-editor {
     background: #f8f8f8;
     border: 1px solid #ccc;
     font-size: 13px;
@@ -408,18 +408,8 @@
     overflow: auto;
     padding: 6px 10px;
     border-radius:3px;
-  }
-
-  pre.editor-colors {
     background: @syntax-background-color;
     border: 1px solid darken(@syntax-background-color, 10%);
-  }
-
-  pre code, pre tt {
-    margin: 0;
-    padding: 0;
-    background-color: transparent;
-    border: none;
   }
 
   kbd {


### PR DESCRIPTION
:warning: Don't merge until https://github.com/atom/atom/pull/5017 is released :warning:

This allows the `.editor-colors` selector to be deprecated in themes. Refs atom/atom#5010.