### PR TITLE
Add support for mermaid charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Show the rendered HTML markdown to the right of the current editor using
 It can be activated from the editor using the `ctrl-shift-m` key-binding and is
 currently enabled for `.markdown`, `.md`, `.mkd`, `.mkdown`, and `.ron` files.
 
-![](https://f.cloud.github.com/assets/671378/2265253/5b1c2ae8-9e7e-11e3-9d93-3fa7caae4710.png)
+![](https://cloud.githubusercontent.com/assets/2261897/5727992/a83ebd88-9b6f-11e4-8cd7-f88e2c82b506.png)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -35,6 +35,9 @@ module.exports =
         'text.plain'
         'text.plain.null-grammar'
       ]
+    mermaidPath:
+      type: 'string'
+      default: 'node_modules/mermaid/dist/mermaid.full.min.js'
 
   activate: ->
     atom.commands.add 'atom-workspace',

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -142,6 +142,11 @@ class MarkdownPreviewView extends ScrollView
       else
         @loading = false
         @html(html)
+        try
+          window.mermaid.init() if window.mermaid
+        catch error
+          @showError(error)
+          return
         @emitter.emit 'did-change-markdown'
         @originalTrigger('markdown-preview:markdown-changed')
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -6,6 +6,7 @@ Highlights = require 'highlights'
 {$} = require 'atom-space-pen-views'
 roaster = null # Defer until used
 {scopeForFenceName} = require './extension-helper'
+{allowUnsafeEval} = require 'loophole'
 
 highlighter = null
 {resourcePath} = atom.getLoadSettings()
@@ -13,9 +14,11 @@ packagePath = path.dirname(__dirname)
 
 exports.toHtml = (text='', filePath, grammar, callback) ->
   roaster ?= require 'roaster'
+  mermaidPath = resolvePath(atom.config.get('markdown-preview.mermaidPath'), filePath)
   options =
     sanitize: false
     breaks: atom.config.get('markdown-preview.breakOnSingleNewline')
+    mermaidPath: mermaidPath
 
   # Remove the <!doctype> since otherwise marked will escape it
   # https://github.com/chjj/marked/issues/354
@@ -31,7 +34,8 @@ exports.toHtml = (text='', filePath, grammar, callback) ->
     html = sanitize(html)
     html = resolveImagePaths(html, filePath)
     html = tokenizeCodeBlocks(html, defaultCodeLanguage)
-    callback(null, html.html().trim())
+    allowUnsafeEval ->
+      callback(null, html.html().trim())
 
 exports.toText = (text, filePath, grammar, callback) ->
   exports.toHtml text, filePath, grammar, (error, html) ->
@@ -43,7 +47,7 @@ exports.toText = (text, filePath, grammar, callback) ->
 
 sanitize = (html) ->
   o = cheerio.load("<div>#{html}</div>")
-  o('script').remove()
+  removeNonMermaidScripts(o)
   attributesToRemove = [
     'onabort'
     'onblur'
@@ -71,23 +75,35 @@ sanitize = (html) ->
   o('*').removeAttr(attribute) for attribute in attributesToRemove
   o.html()
 
+removeNonMermaidScripts = (o) ->
+  scripts = o('script')
+  scripts = scripts.filter ->
+    !cheerio(this).attr('src').match(/mermaid/)
+  scripts.remove()
+
 resolveImagePaths = (html, filePath) ->
   html = $(html)
   for imgElement in html.find('img')
     img = $(imgElement)
     if src = img.attr('src')
-      continue if src.match(/^(https?|atom):\/\//)
-      continue if src.startsWith(process.resourcesPath)
-      continue if src.startsWith(resourcePath)
-      continue if src.startsWith(packagePath)
-
-      if src[0] is '/'
-        unless fs.isFileSync(src)
-          img.attr('src', atom.project.resolve(src.substring(1)))
-      else
-        img.attr('src', path.resolve(path.dirname(filePath), src))
+      img.attr('src', resolvePath(src, filePath))
 
   html
+
+resolvePath = (src, filePath) ->
+  return src unless src
+  return src if src.match(/^(https?|atom):\/\//)
+  return src if src.startsWith(process.resourcesPath)
+  return src if src.startsWith(resourcePath)
+  return src if src.startsWith(packagePath)
+
+  if src[0] is '/'
+    unless fs.isFileSync(src)
+      src = atom.project.resolve(src.substring(1))
+  else
+    src = path.resolve(path.dirname(filePath), src)
+
+  src
 
 tokenizeCodeBlocks = (html, defaultLanguage='text') ->
   html = $(html)

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.0.0",
     "highlights": "0.15.0",
+    "loophole": "^1.0.0",
     "pathwatcher": "^2.0",
-    "roaster": "^1.1.2",
+    "roaster": "deiwin/roaster",
     "temp": "^0.6.0",
     "underscore-plus": "^1.0.0",
     "wrench": "^1.5.0"

--- a/stylesheets/markdown-preview.less
+++ b/stylesheets/markdown-preview.less
@@ -439,4 +439,10 @@
     height: 20px;
     width: 20px;
   }
+
+  .mermaid {
+    .node {
+      fill: #888
+    }
+  }
 }


### PR DESCRIPTION
Okay, so I wanted the MD preview to also draw flowcharts for me. So I updated both the markdown decoder (see gjtorikian/roaster#18) and this preview package to use [knsv/mermaid](https://github.com/knsv/mermaid). 

The outcome is visible in this screenshot that I also added to the readme:
![](https://cloud.githubusercontent.com/assets/2261897/5727992/a83ebd88-9b6f-11e4-8cd7-f88e2c82b506.png)
 (I used [this trick](http://solutionoptimist.com/2013/12/28/awesome-github-tricks/), without actually submitting anything, to effectively upload it to GitHub. Do you know if it will persist?)

I would very much like to hear what you guys think of this. Some of the things I've added seem quite hacky, but I couldn't think of any better solutions either.