### PR TITLE
Ignore npm debug log.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log


### PR DESCRIPTION
Just a minor administrative issue. I assume we want to ignore this debug log.