### PR TITLE
Bind preview command for *.markdown files.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,6 +47,7 @@ module.exports =
         atom.config.set(keyPath, !atom.config.get(keyPath))
 
     previewFile = @previewFile.bind(this)
+    atom.commands.add '.tree-view .file .name[data-name$=\\.markdown]', 'markdown-preview:preview-file', previewFile
     atom.commands.add '.tree-view .file .name[data-name$=\\.md]', 'markdown-preview:preview-file', previewFile
     atom.commands.add '.tree-view .file .name[data-name$=\\.mdown]', 'markdown-preview:preview-file', previewFile
     atom.commands.add '.tree-view .file .name[data-name$=\\.mkd]', 'markdown-preview:preview-file', previewFile


### PR DESCRIPTION
Claims to fix https://github.com/atom/markdown-preview/issues/183.