### PR TITLE
Removes an apparently unused function parameter.

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -12,7 +12,7 @@ highlighter = null
 packagePath = path.dirname(__dirname)
 
 exports.toDOMFragment = (text='', filePath, grammar, callback) ->
-  render text, filePath, grammar, (error, html) ->
+  render text, filePath, (error, html) ->
     return callback(error) if error?
 
     template = document.createElement('template')
@@ -25,14 +25,14 @@ exports.toDOMFragment = (text='', filePath, grammar, callback) ->
     callback(null, domFragment)
 
 exports.toHTML = (text='', filePath, grammar, callback) ->
-  render text, filePath, grammar, (error, html) ->
+  render text, filePath, (error, html) ->
     return callback(error) if error?
     # Default code blocks to be coffee in Literate CoffeeScript files
     defaultCodeLanguage = 'coffee' if grammar?.scopeName is 'source.litcoffee'
     html = tokenizeCodeBlocks(html, defaultCodeLanguage)
     callback(null, html)
 
-render = (text, filePath, grammar, callback) ->
+render = (text, filePath, callback) ->
   roaster ?= require 'roaster'
   options =
     sanitize: false


### PR DESCRIPTION
Unless this hits one of those tricky Javascript variable scoping pitfalls, I believe this change works just fine. I assume that the `grammar` parameter was a leftover from some other code change.