### PR TITLE
Save as HTML properly extract atom-style-editor

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -186,7 +186,7 @@ class MarkdownPreviewView extends ScrollView
   getDocumentStyleSheets: -> # This function exists so we can stub it
     document.styleSheets
 
-  getTextEditorStyles: () ->
+  getTextEditorStyles: ->
 
     textEditorStyles = document.createElement("atom-styles")
     textEditorStyles.setAttribute "context", "atom-text-editor"
@@ -199,7 +199,7 @@ class MarkdownPreviewView extends ScrollView
     Array.prototype.slice.apply(textEditorStyles.childNodes).map (styleElement) ->
       styleElement.innerText
 
-  getMarkdownPreviewCSS: () ->
+  getMarkdownPreviewCSS: ->
     markdowPreviewRules = []
     ruleRegExp = /\.markdown-preview/
     cssUrlRefExp = /url\(atom:\/\/markdown-preview\/assets\/(.*)\)/

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -192,17 +192,22 @@ class MarkdownPreviewView extends ScrollView
 
       textEditorStyles = document.createElement("atom-styles")
       textEditorStyles.setAttribute "context", "atom-text-editor"
-      document.body.appendChild textEditorStyles
 
-      extractStyles = ->
-        styles = Array.prototype.slice.apply(textEditorStyles.childNodes).map (styleElement) ->
+      # Rewrap initialize so we know when it's finished
+      initialInitialize = textEditorStyles.initialize
+
+      textEditorStyles.initialize = ->
+
+        # Call original initialize method
+        initialInitialize.apply(this)
+
+        # Extract style afterward
+        resolve Array.prototype.slice.apply(textEditorStyles.childNodes).map (styleElement) ->
           styleElement.innerText
-        textEditorStyles.remove()
-        styles
 
-      setTimeout ->
-        resolve(extractStyles())
-      , 1000
+        textEditorStyles.remove()
+
+      document.body.appendChild textEditorStyles
 
   getMarkdownPreviewCSS: () ->
     markdowPreviewRules = []

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -212,16 +212,16 @@ describe "MarkdownPreviewView", ->
 
     describe "text editor style extraction", ->
 
-      [disposableStyleSheet, disposableStyleSheet2, extractedStyles] = []
+      [extractedStyles] = []
 
       textEditorStyle = ".editor-style .extraction-test { color: blue; }"
       unrelatedStyle  = ".something else { color: red; }"
 
       beforeEach ->
-        disposableStyleSheet = atom.styles.addStyleSheet textEditorStyle,
+        atom.styles.addStyleSheet textEditorStyle,
           context: 'atom-text-editor'
 
-        disposableStyleSheet2 = atom.styles.addStyleSheet unrelatedStyle,
+        atom.styles.addStyleSheet unrelatedStyle,
           context: 'unrelated-context'
 
         extractedStyles = preview.getTextEditorStyles()

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -200,7 +200,7 @@ describe "MarkdownPreviewView", ->
       runs ->
         spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
         spyOn(preview, 'getDocumentStyleSheets').andReturn(markdownPreviewStyles)
-        spyOn(preview, 'getTextEditorStyles').andReturn(atomTextEditorStyles)
+        spyOn(preview, 'getTextEditorStyles').andReturn(Promise.resolve(atomTextEditorStyles))
         atom.commands.dispatch preview.element, 'core:save-as'
 
       waitsFor ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -210,6 +210,31 @@ describe "MarkdownPreviewView", ->
         expect(fs.isFileSync(outputPath)).toBe true
         expect(atom.workspace.getActiveTextEditor().getText()).toBe expectedOutput
 
+    describe "text editor style extraction", ->
+
+      disposableStyleSheet = disposableStyleSheet2 = extractedStyles = null
+      textEditorStyle = ".editor-style .extraction-test { color: blue; }"
+      unrelatedStyle  = ".something else { color: red; }"
+
+      beforeEach ->
+        disposableStyleSheet = atom.styles.addStyleSheet textEditorStyle,
+          context: 'atom-text-editor'
+
+        disposableStyleSheet2 = atom.styles.addStyleSheet unrelatedStyle,
+          context: 'unrelated-context'
+
+        extractedStyles = preview.getTextEditorStyles()
+
+      it "returns an array containing atom-text-editor css style strings", ->
+        expect(extractedStyles.indexOf(textEditorStyle)).toBeGreaterThan(-1)
+
+      it "does not return other styles", ->
+        expect(extractedStyles.indexOf(unrelatedStyle)).toBe(-1)
+
+      afterEach ->
+        disposableStyleSheet.dispose()
+        disposableStyleSheet2.dispose()
+
   describe "when core:copy is triggered", ->
     it "writes the rendered HTML to the clipboard", ->
       preview.destroy()

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -212,7 +212,8 @@ describe "MarkdownPreviewView", ->
 
     describe "text editor style extraction", ->
 
-      disposableStyleSheet = disposableStyleSheet2 = extractedStyles = null
+      [disposableStyleSheet, disposableStyleSheet2, extractedStyles] = []
+
       textEditorStyle = ".editor-style .extraction-test { color: blue; }"
       unrelatedStyle  = ".something else { color: red; }"
 
@@ -230,10 +231,6 @@ describe "MarkdownPreviewView", ->
 
       it "does not return other styles", ->
         expect(extractedStyles.indexOf(unrelatedStyle)).toBe(-1)
-
-      afterEach ->
-        disposableStyleSheet.dispose()
-        disposableStyleSheet2.dispose()
 
   describe "when core:copy is triggered", ->
     it "writes the rendered HTML to the clipboard", ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -200,7 +200,7 @@ describe "MarkdownPreviewView", ->
       runs ->
         spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
         spyOn(preview, 'getDocumentStyleSheets').andReturn(markdownPreviewStyles)
-        spyOn(preview, 'getTextEditorStyles').andReturn(Promise.resolve(atomTextEditorStyles))
+        spyOn(preview, 'getTextEditorStyles').andReturn(atomTextEditorStyles)
         atom.commands.dispatch preview.element, 'core:save-as'
 
       waitsFor ->


### PR DESCRIPTION
The `atom-text-editor` `<style>` element extraction was synchronous and actually broken. This PR target is to do it properly.

The initial commit fixes the problem but in a terrible way, using `setTimeout` instead of a proper _shadow-DOM replacement_finished_-like event. I have no idea what is the event to listen to.