### PR TITLE
Remove line-cursor decoration in editors in preview

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -116,7 +116,8 @@ convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
     preElement.remove()
 
     editor = editorElement.getModel()
-    editor.getCursor().destroy()
+    # remove the default selection of a line in each editor
+    editor.getDecorations(class: 'cursor-line', type: 'line')[0].destroy()
     editor.setText(codeBlock.textContent.trim())
     if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
       editor.setGrammar(grammar)

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -116,6 +116,7 @@ convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
     preElement.remove()
 
     editor = editorElement.getModel()
+    editor.getCursor().destroy()
     editor.setText(codeBlock.textContent.trim())
     if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
       editor.setGrammar(grammar)

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -70,6 +70,11 @@ describe "MarkdownPreviewView", ->
       waitsForPromise ->
         preview.renderMarkdown()
 
+    it "removes line decorations on rendered code blocks", ->
+      editor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
+      decorations = plainEditor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
+      expect(decorations.length).toBe 0
+
     describe "when the code block's fence name has a matching grammar", ->
       it "assigns the grammar on the atom-text-editor", ->
         rubyEditor = preview.find("atom-text-editor[data-grammar='source ruby']")
@@ -98,17 +103,6 @@ describe "MarkdownPreviewView", ->
             return x++;
           }
         """
-
-  describe "editor behaves read-only", ->
-    beforeEach ->
-      waitsForPromise ->
-        preview.renderMarkdown()
-
-    describe "when a code block is rendered", ->
-      it "it does not have line-cursor decorations", ->
-        plainEditor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
-        decorations = plainEditor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
-        expect(decorations.length).toBe 0
 
   describe "image resolving", ->
     beforeEach ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -99,6 +99,17 @@ describe "MarkdownPreviewView", ->
           }
         """
 
+  describe "editor behaves read-only", ->
+    beforeEach ->
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+    describe "when a code block is rendered", ->
+      it "it does not have line-cursor decorations", ->
+        plainEditor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
+        decorations = plainEditor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
+        expect(decorations.length).toBe 0
+
   describe "image resolving", ->
     beforeEach ->
       waitsForPromise ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -70,7 +70,7 @@ describe "MarkdownPreviewView", ->
       waitsForPromise ->
         preview.renderMarkdown()
 
-    fit "removes line decorations on rendered code blocks", ->
+    it "removes line decorations on rendered code blocks", ->
       editor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
       decorations = editor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
       expect(decorations.length).toBe 0

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -70,9 +70,9 @@ describe "MarkdownPreviewView", ->
       waitsForPromise ->
         preview.renderMarkdown()
 
-    it "removes line decorations on rendered code blocks", ->
+    fit "removes line decorations on rendered code blocks", ->
       editor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
-      decorations = plainEditor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
+      decorations = editor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
       expect(decorations.length).toBe 0
 
     describe "when the code block's fence name has a matching grammar", ->


### PR DESCRIPTION
This removes the default one line selection in each editor when a part of a markdown preview because they're not needed/expected here—they don't correlate to anything in the actual editor. 

The code assumes there will be just one `class: 'cursor-line', type: 'line'`, and there should be, but destroying all could create something unexpected. 

In future times we'll work towards a read-only atom-editor :balloon: 

- [x] add spec to check for 0 `cursor-line`

**before**
![screen shot 2015-03-20 at 4 51 13 pm](https://cloud.githubusercontent.com/assets/1305617/6763281/becb8152-cf32-11e4-98f1-44f61102b499.png)
**after**
![screen shot 2015-03-20 at 4 50 18 pm](https://cloud.githubusercontent.com/assets/1305617/6763282/c4c1a78a-cf32-11e4-894d-2066546f40ea.png)