### PR TITLE
Stop scrolling to top in markdown preview

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -18,7 +18,7 @@ class MarkdownPreviewView extends ScrollView
     super
     @emitter = new Emitter
     @disposables = new CompositeDisposable
-    @showedLoading = false
+    @loaded = false
 
   attached: ->
     return if @isAttached
@@ -109,7 +109,6 @@ class MarkdownPreviewView extends ScrollView
         @css('zoom', 1)
 
     changeHandler = =>
-      @showedLoading = true
       @renderMarkdown()
 
       # TODO: Remove paneForURI call when ::paneForItem is released
@@ -131,8 +130,7 @@ class MarkdownPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'markdown-preview.breakOnSingleNewline', changeHandler
 
   renderMarkdown: ->
-    if @showedLoading is false
-      @showLoading()
+    @showLoading() unless @loaded
     @getMarkdownSource().then (source) => @renderMarkdownText(source) if source?
 
   getMarkdownSource: ->
@@ -155,6 +153,7 @@ class MarkdownPreviewView extends ScrollView
         @showError(error)
       else
         @loading = false
+        @loaded = true
         @html(domFragment)
         @emitter.emit 'did-change-markdown'
         @originalTrigger('markdown-preview:markdown-changed')

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -18,6 +18,7 @@ class MarkdownPreviewView extends ScrollView
     super
     @emitter = new Emitter
     @disposables = new CompositeDisposable
+    @showedLoading = false
 
   attached: ->
     return if @isAttached
@@ -108,6 +109,7 @@ class MarkdownPreviewView extends ScrollView
         @css('zoom', 1)
 
     changeHandler = =>
+      @showedLoading = true
       @renderMarkdown()
 
       # TODO: Remove paneForURI call when ::paneForItem is released
@@ -129,7 +131,8 @@ class MarkdownPreviewView extends ScrollView
     @disposables.add atom.config.onDidChange 'markdown-preview.breakOnSingleNewline', changeHandler
 
   renderMarkdown: ->
-    @showLoading()
+    if @showedLoading is false
+      @showLoading()
     @getMarkdownSource().then (source) => @renderMarkdownText(source) if source?
 
   getMarkdownSource: ->
@@ -152,8 +155,7 @@ class MarkdownPreviewView extends ScrollView
         @showError(error)
       else
         @loading = false
-        @empty()
-        @append(domFragment)
+        @html(domFragment)
         @emitter.emit 'did-change-markdown'
         @originalTrigger('markdown-preview:markdown-changed')
 

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -92,6 +92,18 @@ describe "Markdown preview package", ->
       expect(previewPane.getActiveItem()).toBeUndefined()
 
     describe "when the editor is modified", ->
+      it "re-renders the preview", ->
+        spyOn(preview, 'showLoading')
+
+        markdownEditor = atom.workspace.getActiveTextEditor()
+        markdownEditor.setText "Hey!"
+
+        waitsFor ->
+          preview.text().indexOf("Hey!") >= 0
+
+        runs ->
+          expect(preview.showLoading).not.toHaveBeenCalled()
+
       it "invokes ::onDidChangeMarkdown listeners", ->
         markdownEditor = atom.workspace.getActiveTextEditor()
         preview.onDidChangeMarkdown(listener = jasmine.createSpy('didChangeMarkdownListener'))


### PR DESCRIPTION
This PR fixes a bug that resulted in every change in a markdown file that included a code element triggering a scroll to the top of the preview pane.

Turns out the problem was in calling the `showLoading()` method which replaces all the html with a loading spinner. The thinking is that because the inclusion of code elements as mini atom editors made everything just a bit slower, enough that when the html was replaced by a one line spinner it was scrolled to the top.

This PR makes it so that the spinner is only used when a preview pane is first opened and not after every change.

:tophat: to @maxogden and Atomies for helping debug this mysterious :bug: :zap: 

cc @nathansobo wanted to also mention this includes [a change](https://github.com/atom/markdown-preview/compare/jl-stop-scrolling-md-preview?expand=1#diff-ddc9dd0264ef4241a4a7fb6db97acd52R157) from `empty()` and `append()` to just `html()` which is likely safer by not risking leaving it empty. 