### PR TITLE
Handle click events on relative links.

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -6,6 +6,7 @@ Grim = require 'grim'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
 {File} = require 'pathwatcher'
+String = require 'string'
 
 renderer = require './renderer'
 
@@ -19,6 +20,17 @@ class MarkdownPreviewView extends ScrollView
     @emitter = new Emitter
     @disposables = new CompositeDisposable
     @loaded = false
+    markdownPreviewView = this
+    @on 'click', 'a', ->
+        href = $(this).attr('href')
+        if(String(href).startsWith("https://") or
+             String(href).startsWith("http://"))
+            return
+        p = path.dirname(markdownPreviewView.getPath())
+        options = searchAllPanes: true
+        if atom.config.get('markdown-preview.openPreviewInSplitPane')
+            options.split = 'left'
+        callenEditor = atom.workspace.open( path.resolve("/", p, href), options )
 
   attached: ->
     return if @isAttached

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -9,6 +9,7 @@ fs = require 'fs-plus'
 String = require 'string'
 
 renderer = require './renderer'
+main = require './main'
 
 module.exports =
 class MarkdownPreviewView extends ScrollView
@@ -30,7 +31,9 @@ class MarkdownPreviewView extends ScrollView
         options = searchAllPanes: true
         if atom.config.get('markdown-preview.openPreviewInSplitPane')
             options.split = 'left'
-        callenEditor = atom.workspace.open( path.resolve("/", p, href), options )
+        atom.workspace.open( path.resolve("/", p, href), options ).done (callenEditor) ->
+            if callenEditor.getGrammar().name is "GitHub Markdown"
+                main.addPreviewForEditor(callenEditor)
 
   attached: ->
     return if @isAttached
@@ -85,6 +88,8 @@ class MarkdownPreviewView extends ScrollView
       else
         # The editor this preview was created for has been closed so close
         # this preview since a preview cannot be rendered without an editor
+        # Accessing PaneView via $::view() is deprecated. Use the raw DOM node
+        # or underlying model object instead.
         @parents('.pane').view()?.destroyItem(this)
 
     if atom.workspace?

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "roaster": "^1.1.2",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0",
-    "wrench": "^1.5.0"
+    "wrench": "^1.5.0",
+    "string": "x"
   }
 }

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -38,7 +38,7 @@ describe "MarkdownPreviewView", ->
       preview.showError("Not a real file")
       expect(preview.text()).toContain "Failed"
 
-    it "Handle click events on relativ links"
+    it "Handle click events on relative links"
 
   describe "serialization", ->
     newPreview = null

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -38,6 +38,8 @@ describe "MarkdownPreviewView", ->
       preview.showError("Not a real file")
       expect(preview.text()).toContain "Failed"
 
+    it "Handle click events on relativ links"
+
   describe "serialization", ->
     newPreview = null
 


### PR DESCRIPTION
Probably this fix #85.
If click on a relative link open the file and if it is a markdown file open the markdown preview.