### PR TITLE
:bug: fix for utf8 mangling in markdown preview html

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -276,6 +276,7 @@ class MarkdownPreviewView extends ScrollView
             <!DOCTYPE html>
             <html>
               <head>
+                  <meta charset="utf-8" />
                   <title>#{title}</title>
                   <style>#{@getMarkdownPreviewCSS()}</style>
               </head>

--- a/spec/fixtures/saved-html.html
+++ b/spec/fixtures/saved-html.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+      <meta charset="utf-8" />
       <title>code-block</title>
       <style>.markdown-preview { color: orange; }
 .markdown-preview .host { color: purple; }


### PR DESCRIPTION
quick fix for [utf-8 mangling issue](https://github.com/atom/markdown-preview/issues/226) which occurs when saving a markdown preview to html with utf-8 characters.

I've tested (by inserting the `meta` tag on the generated html) on both linux and osx, and it seems to fix the issue.