### PR TITLE
Style <code> blocks consistently with GitHub.com

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -398,8 +398,6 @@
     text-shadow: none;
   }
 
-  code { white-space: nowrap; }
-
   atom-text-editor {
     background: #f8f8f8;
     border: 1px solid #ccc;


### PR DESCRIPTION
Resolve #230 by removing the `white-space: nowrap` directive.