### PR TITLE
Save as HTML also exports base css

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -202,14 +202,16 @@ class MarkdownPreviewView extends ScrollView
 
   getMarkdownPreviewCSS: ->
     markdowPreviewRules = []
-    ruleRegExp = /\.markdown-preview/
+    packageRuleCSSRegExp = /\.markdown-preview/
+    baseCSSRegExp = /bootstrap\.less$/
     cssUrlRefExp = /url\(atom:\/\/markdown-preview\/assets\/(.*)\)/
 
     for stylesheet in @getDocumentStyleSheets()
       if stylesheet.rules?
+        isBaseCSS = stylesheet.ownerNode?.sourcePath?.match(baseCSSRegExp)?
         for rule in stylesheet.rules
-          # We only need `.markdown-review` css
-          markdowPreviewRules.push(rule.cssText) if rule.selectorText?.match(ruleRegExp)?
+          # We only need `.markdown-review` css and base css
+          markdowPreviewRules.push(rule.cssText) if isBaseCSS || rule.selectorText?.match(packageRuleCSSRegExp)?
 
     markdowPreviewRules
       .concat(@getTextEditorStyles())

--- a/spec/fixtures/saved-html.html
+++ b/spec/fixtures/saved-html.html
@@ -5,6 +5,7 @@
       <title>code-block</title>
       <style>.markdown-preview { color: orange; }
 .markdown-preview .host { color: purple; }
+basecss { color: pink; }
 pre.editor-colors .line { color: brown; }
 pre.editor-colors .number { color: cyan; }
 pre.editor-colors .host .something { color: black; }

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -188,6 +188,13 @@ describe "MarkdownPreviewView", ->
             createRule ".not-included", "{ color: green; }"
             createRule ".markdown-preview :host", "{ color: purple; }"
           ]
+        }, {
+          rules: [
+            createRule "basecss", "{ color: pink; }"
+          ],
+          ownerNode: {
+            sourcePath: "/anywhere/bootstrap.less"
+          }
         }
       ]
 


### PR DESCRIPTION
I am not quite happy with the way I extract the base css, taking it from the stylesheets having `bootstrap.less` as a source, which contain `normalize.css` and other stuff.

I'd be happy to change it if anyone has a better idea.

Fixes #232