### PR TITLE
Keybinding Resolver conflict with Emmet

### DIFF
--- a/keymaps/markdown-preview.cson
+++ b/keymaps/markdown-preview.cson
@@ -1,4 +1,4 @@
-'atom-workspace, atom-workspace atom-text-editor':
+'.editor:not(.mini)':
   'ctrl-M': 'markdown-preview:toggle'
 
 '.platform-darwin .markdown-preview':


### PR DESCRIPTION
There is a conflict with the ctrl+M key map when the user have the Emmet package installed.
This change will prevent the error. also, the Keybinding resolver doesn't support the comma operator.