### PR TITLE
#114: only activate ctrl-shift-m keybinding when editing MarkDown source

### DIFF
--- a/keymaps/markdown-preview.cson
+++ b/keymaps/markdown-preview.cson
@@ -1,4 +1,4 @@
-'atom-workspace, atom-workspace atom-text-editor':
+'atom-text-editor[data-grammar="source gfm"]':
   'ctrl-M': 'markdown-preview:toggle'
 
 '.platform-darwin .markdown-preview':


### PR DESCRIPTION
Two pull requests that goes together : 
  - **markdown-preview**: only activate `ctrl-shift-m` when in markdown editing context (to free that shortkey for all other grammars)
  - **[bracket-matcher] (https://github.com/atom/bracket-matcher/pull/132)**: make use of `ctrl-shift-m` for *select-inside-brackets* action