### PR TITLE
Verify file path is string before reading and rendering

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 url = require 'url'
+fs = require 'fs-plus'
 
 MarkdownPreviewView = null # Defer until used
 renderer = null # Defer until used

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,9 +14,8 @@ isMarkdownPreviewView = (object) ->
 atom.deserializers.add
   name: 'MarkdownPreviewView'
   deserialize: (state) ->
-    if state.constructor is Object
-      if state.editorId or fs.isFileSync(state.filePath)
-        createMarkdownPreviewView(state)
+    if state.editorId or fs.isFileSync(state.filePath)
+      createMarkdownPreviewView(state)
 
 module.exports =
   config:

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,7 +14,9 @@ isMarkdownPreviewView = (object) ->
 atom.deserializers.add
   name: 'MarkdownPreviewView'
   deserialize: (state) ->
-    createMarkdownPreviewView(state) if state.constructor is Object
+    if state.constructor is Object
+      if state.editorId or fs.isFileSync(state.filePath)
+        createMarkdownPreviewView(state)
 
 module.exports =
   config:

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -35,7 +35,7 @@ class MarkdownPreviewView extends ScrollView
 
   serialize: ->
     deserializer: 'MarkdownPreviewView'
-    filePath: @getPath()
+    filePath: @getPath() ? @filePath
     editorId: @editorId
 
   destroy: ->

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -135,7 +135,7 @@ class MarkdownPreviewView extends ScrollView
     @getMarkdownSource().then (source) => @renderMarkdownText(source) if source?
 
   getMarkdownSource: ->
-    if @file? and typeof @file.path is 'string'
+    if @file?.getPath()
       @file.read()
     else if @editor?
       Promise.resolve(@editor.getText())

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -135,7 +135,7 @@ class MarkdownPreviewView extends ScrollView
     @getMarkdownSource().then (source) => @renderMarkdownText(source) if source?
 
   getMarkdownSource: ->
-    if @file?
+    if @file? and typeof @file.path is 'string'
       @file.read()
     else if @editor?
       Promise.resolve(@editor.getText())

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -42,12 +42,23 @@ describe "MarkdownPreviewView", ->
     newPreview = null
 
     afterEach ->
-      newPreview.destroy()
+      newPreview?.destroy()
 
-    it "recreates the file when serialized/deserialized", ->
+    it "recreates the preview when serialized/deserialized", ->
       newPreview = atom.deserializers.deserialize(preview.serialize())
       jasmine.attachToDOM(newPreview.element)
       expect(newPreview.getPath()).toBe preview.getPath()
+
+    it "does not recreate a preview when the file no longer exists", ->
+      filePath = path.join(temp.mkdirSync('markdown-preview-'), 'foo.md')
+      fs.writeFileSync(filePath, '# Hi')
+
+      preview = new MarkdownPreviewView({filePath})
+      serialized = preview.serialize()
+      fs.removeSync(filePath)
+
+      newPreview = atom.deserializers.deserialize(serialized)
+      expect(newPreview).toBeUndefined()
 
     it "serializes the editor id when opened for an editor", ->
       preview.destroy()


### PR DESCRIPTION
This changes `getMarkdownSource` to first verify `@file` exists and then further check that the `path` it contains is a `string`. This should eliminate uncaught exceptions from trying to read files from paths that aren't strings.

Why aren't paths strings? To be continued... 

**todo**
- [x] add spec 

Closes #264