### PR TITLE
Don't alter image source without root directory

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -92,7 +92,8 @@ resolveImagePaths = (html, filePath) ->
 
       if src[0] is '/'
         unless fs.isFileSync(src)
-          img.attr('src', path.join(rootDirectory, src.substring(1)))
+          if rootDirectory
+            img.attr('src', path.join(rootDirectory, src.substring(1)))
       else
         img.attr('src', path.resolve(path.dirname(filePath), src))
 

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -351,8 +351,7 @@ describe "Markdown preview package", ->
 
   describe "when there is an image with a relative path and no directory", ->
     it "does not alter the image src", ->
-      runs ->
-        atom.project.removePath(projectPath) for projectPath in atom.project.getPaths()
+      atom.project.removePath(projectPath) for projectPath in atom.project.getPaths()
 
       filePath = path.join(temp.mkdirSync('atom'), 'bar.md')
       fs.writeFileSync(filePath, "![rel path](/foo.png)")

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -349,6 +349,25 @@ describe "Markdown preview package", ->
 
       runs -> expect(preview.find('atom-text-editor')).toExist()
 
+  fdescribe "when there is an image with a relative path and no directory", ->
+    it "does not alter the image src", ->
+      runs ->
+        atom.project.removePath(projectPath) for projectPath in atom.project.getPaths()
+
+      filePath = path.join(temp.mkdirSync('atom'), 'bar.md')
+      fs.writeFileSync(filePath, "![rel path](/foo.png)")
+
+      waitsForPromise ->
+        atom.workspace.open(filePath)
+
+      runs -> atom.commands.dispatch workspaceElement, 'markdown-preview:toggle'
+      expectPreviewInSplitPane()
+
+      runs ->
+        expect(preview[0].innerHTML).toBe """
+          <p><img src="/foo.png" alt="rel path"></p>
+        """
+
   describe "GitHub style markdown preview", ->
     beforeEach ->
       atom.config.set 'markdown-preview.useGitHubStyle', false

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -349,7 +349,7 @@ describe "Markdown preview package", ->
 
       runs -> expect(preview.find('atom-text-editor')).toExist()
 
-  fdescribe "when there is an image with a relative path and no directory", ->
+  describe "when there is an image with a relative path and no directory", ->
     it "does not alter the image src", ->
       runs ->
         atom.project.removePath(projectPath) for projectPath in atom.project.getPaths()


### PR DESCRIPTION
This makes sure a root directory exists before Atom tries to figure out the path of an image with a relative url. 

Closes https://github.com/atom/markdown-preview/issues/270