### PR TITLE
Remove scrollbar on code blocks

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -128,6 +128,9 @@
     line-height: 1.45;
     background-color: @syntax-background-color;
     border-radius: 3px;
+    &::shadow ::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   atom-text-editor {

--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -128,8 +128,19 @@
     line-height: 1.45;
     background-color: @syntax-background-color;
     border-radius: 3px;
-    &::shadow ::-webkit-scrollbar {
-      display: none;
+
+    // only show scrollbars on hover
+    .scrollbars-visible-always &::shadow {
+      .vertical-scrollbar,
+      .horizontal-scrollbar {
+        visibility: hidden;
+      }
+    }
+    .scrollbars-visible-always &:hover::shadow {
+      .vertical-scrollbar,
+      .horizontal-scrollbar {
+        visibility: visible;
+      }
     }
   }
 


### PR DESCRIPTION
It's still possible to scroll, but it just doesn't show any scrollbars.

Improves #286 + #234