### PR TITLE
Themed Markdown Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,27 @@
 # Markdown Preview package [![Build Status](https://travis-ci.org/atom/markdown-preview.svg?branch=master)](https://travis-ci.org/atom/markdown-preview)
 
 Show the rendered HTML markdown to the right of the current editor using
-`ctrl-shift-m`
+`ctrl-shift-m`.
 
 It can be activated from the editor using the `ctrl-shift-m` key-binding and is
 currently enabled for `.markdown`, `.md`, `.mdown`, `.mkd`, `.mkdown`, `.ron`, and `.txt` files.
 
-![](https://f.cloud.github.com/assets/671378/2265253/5b1c2ae8-9e7e-11e3-9d93-3fa7caae4710.png)
+![markdown-preview](https://cloud.githubusercontent.com/assets/378023/10013086/24cad23e-6149-11e5-90e6-663009210218.png)
+
+## Customize
+
+By default Markdown Preview uses the colors of the active syntax theme. Enable
+
+- [x] Use GitHub.com style
+
+in the __package settings__ to make it look closer to how markdown files get rendered on github.com.
+
+![markdown-preview GitHub style](https://cloud.githubusercontent.com/assets/378023/10013087/24ccc7ec-6149-11e5-97ea-53a842a715ea.png)
+
+To customize even further, the styling can be overridden in your `styles.less` file. For example:
+
+```css
+.markdown-preview.markdown-preview {
+  background-color: #444;
+}
+```

--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -8,147 +8,96 @@
 @import "syntax-variables";
 
 .markdown-preview:not([data-use-github-style]) {
-  box-sizing: border-box;
   padding: 2em;
   font-size: 1.25em;
   color: @syntax-text-color;
   background-color: @syntax-background-color;
   overflow: scroll;
 
-  code {
-    color: #333;
-  }
-
-  // Headings
-  h1, h2, h3, h4, h5, h6 {
-    -webkit-font-smoothing: antialiased;
-    cursor: text;
-  }
-
-  & > h1:first-child,
-  & > h1:first-child + h2,
-  & > h2:first-child,
-  & > h3:first-child,
-  & > h4:first-child,
-  & > h5:first-child,
-  & > h6:first-child {
+  & > :first-child {
     margin-top: 0;
-    padding-top: 0;
   }
 
-  a, a code {
+
+  // Headings --------------------
+
+  h1, h2, h3, h4, h5, h6 {
+    line-height: 1.2;
+    margin-top: 1em;
+    margin-bottom: .5em;
+  }
+
+  h1 { font-size: 2.4em; font-weight: 300; }
+  h2 { font-size: 2.0em; font-weight: 300; }
+  h3 { font-size: 1.8em; font-weight: 400; }
+  h4 { font-size: 1.5em; font-weight: 500; }
+  h5 { font-size: 1.2em; font-weight: 600; }
+  h6 { font-size: 1.0em; font-weight: 600; }
+
+  h1 { border-bottom: 2px solid @syntax-indent-guide-color; }
+  h2 { border-bottom: 1px solid @syntax-indent-guide-color; }
+
+
+  // Link --------------------
+
+  a,
+  a code {
     color: #4183c4;
   }
 
-  // fixes margin on shit like:
-  // <a name='the-heading'>
-  // <h1>The Heading</h1></a>
-  a:first-child {
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 0;
-      padding-top: 0;
-    }
+
+  // Images --------------------
+
+  img {
+    max-width: 100%;
   }
 
-  h1 + p,
-  h2 + p,
-  h3 + p,
-  h4 + p,
-  h5 + p,
-  h6 + p {
-    margin-top: 0;
-  }
 
-  // ReST first graf in nested list
-  li p.first {
-    display: inline-block;
-  }
-
-  // Lists, Blockquotes & Such
-  ul,
-  ol {
-    li > :first-child,
-    li ul:first-of-type {
-      margin-top: 0;
-    }
-  }
-
-  ol > li {
-    list-style-type: decimal;
-  }
-
-  ul > li {
-    list-style-type: disc;
-  }
-
-  dl dt {
-    &:first-child {
-      padding: 0;
-    }
-
-    & > :first-child {
-      margin-top: 0;
-    }
-
-    & > :last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  dl dd {
-    & > :first-child {
-      margin-top: 0;
-    }
-
-    & > :last-child {
-      margin-bottom: 0;
-    }
-  }
+  // Blockquotes --------------------
 
   blockquote {
+    border-color: @syntax-indent-guide-color;
     p {
       font-size: 16px;
       line-height: 1.5;
     }
   }
 
+
+  // HR --------------------
+
+  hr {
+    border-top: 2px dashed @syntax-indent-guide-color;
+  }
+
+
+  // Table --------------------
+
+  table {
+    width: 100%;
+    margin-bottom: 1em;
+  }
+
+  th,
+  td {
+    padding: .3em;
+    border: 1px solid @syntax-indent-guide-color;
+  }
+
+
+  // Code --------------------
+
+  code {
+    color: @syntax-text-color;
+    background-color: contrast(@syntax-background-color, lighten(@syntax-background-color, 8%), darken(@syntax-background-color, 6%));
+  }
+
   atom-text-editor {
-    padding: 16px;
-    overflow: auto;
-    font-size: 84%; // Hack to get default size to 13px.
-    line-height: 1.45;
-    background-color: @syntax-background-color;
+    margin-bottom: 1em;
+    padding: 1em;
+    font-size: .92em;
     border-radius: 3px;
-
-    // only show scrollbars on hover
-    .scrollbars-visible-always &::shadow {
-      .vertical-scrollbar,
-      .horizontal-scrollbar {
-        visibility: hidden;
-      }
-    }
-    .scrollbars-visible-always &:hover::shadow {
-      .vertical-scrollbar,
-      .horizontal-scrollbar {
-        visibility: visible;
-      }
-    }
-  }
-
-  atom-text-editor {
-    margin-bottom: 16px;
-    word-break: normal;
-  }
-
-  code,
-  tt,
-  atom-text-editor {
-    font-family: Consolas, "Liberation Mono", Courier, monospace;
-  }
-
-  .emoji {
-    height: 20px;
-    width: 20px;
+    background-color: contrast(@syntax-background-color, lighten(@syntax-background-color, 4%), darken(@syntax-background-color, 4%));
   }
 
 }

--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -83,6 +83,14 @@
   }
 
 
+  // List --------------------
+
+  & > ul,
+  & > ol {
+    margin-bottom: @margin;
+  }
+
+
   // Blockquotes --------------------
 
   blockquote {

--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -8,11 +8,24 @@
 @import "syntax-variables";
 
 .markdown-preview:not([data-use-github-style]) {
+
+  @fg: @syntax-text-color;
+  @bg: @syntax-background-color;
+
+  @fg-accent: @syntax-cursor-color;
+  @fg-strong: contrast(@bg, darken(@fg, 32%), lighten(@fg, 32%));
+  @fg-subtle: contrast(@fg, lighten(@fg, 16%), darken(@fg, 16%));
+
+  @border: contrast(@bg, lighten(@bg, 16%), darken(@bg, 16%));
+
+  @margin: 1.5em;
+
+
   padding: 2em;
-  font-size: 1.25em;
-  color: @syntax-text-color;
-  background-color: @syntax-background-color;
-  overflow: scroll;
+  font-size: 1.2em;
+  color: @fg;
+  background-color: @bg;
+  overflow: auto;
 
   & > :first-child {
     margin-top: 0;
@@ -23,26 +36,35 @@
 
   h1, h2, h3, h4, h5, h6 {
     line-height: 1.2;
-    margin-top: 1em;
-    margin-bottom: .5em;
+    margin-top: @margin;
+    margin-bottom: @margin/3;
+    color: @fg-strong;
   }
 
   h1 { font-size: 2.4em; font-weight: 300; }
-  h2 { font-size: 2.0em; font-weight: 300; }
-  h3 { font-size: 1.8em; font-weight: 400; }
-  h4 { font-size: 1.5em; font-weight: 500; }
-  h5 { font-size: 1.2em; font-weight: 600; }
+  h2 { font-size: 1.8em; font-weight: 300; }
+  h3 { font-size: 1.4em; font-weight: 400; }
+  h4 { font-size: 1.2em; font-weight: 500; }
+  h5 { font-size: 1.1em; font-weight: 600; }
   h6 { font-size: 1.0em; font-weight: 600; }
 
-  h1 { border-bottom: 2px solid @syntax-indent-guide-color; }
-  h2 { border-bottom: 1px solid @syntax-indent-guide-color; }
+
+  // Emphasis --------------------
+
+  strong {
+    color: @fg-strong;
+  }
+
+  del {
+    color: @fg-subtle;
+  }
 
 
   // Link --------------------
 
   a,
   a code {
-    color: #4183c4;
+    color: @fg-accent;
   }
 
 
@@ -53,51 +75,74 @@
   }
 
 
+  // Paragraph --------------------
+
+  & > p {
+    margin-top: 0;
+    margin-bottom: @margin;
+  }
+
+
   // Blockquotes --------------------
 
   blockquote {
-    border-color: @syntax-indent-guide-color;
-    p {
-      font-size: 16px;
-      line-height: 1.5;
-    }
+    margin: @margin 0;
+    font-size: inherit;
+    color: @fg-subtle;
+    border-color: @border;
+    border-width: 4px;
   }
 
 
   // HR --------------------
 
   hr {
-    border-top: 2px dashed @syntax-indent-guide-color;
+    margin: @margin*2 0;
+    border-top: 2px dashed @border;
+    background: none;
   }
 
 
   // Table --------------------
 
   table {
-    width: 100%;
-    margin-bottom: 1em;
+    margin: @margin 0;
+  }
+
+  th {
+    color: @fg-strong;
   }
 
   th,
   td {
-    padding: .3em;
-    border: 1px solid @syntax-indent-guide-color;
+    padding: .66em 1em;
+    border: 1px solid @border;
   }
 
 
   // Code --------------------
 
   code {
-    color: @syntax-text-color;
+    color: @fg-strong;
     background-color: contrast(@syntax-background-color, lighten(@syntax-background-color, 8%), darken(@syntax-background-color, 6%));
   }
 
   atom-text-editor {
-    margin-bottom: 1em;
+    margin: @margin 0;
     padding: 1em;
     font-size: .92em;
     border-radius: 3px;
     background-color: contrast(@syntax-background-color, lighten(@syntax-background-color, 4%), darken(@syntax-background-color, 4%));
+  }
+
+
+  // KBD --------------------
+
+  kbd {
+    color: @fg-strong;
+    border: 1px solid @border;
+    border-bottom: 2px solid darken(@border, 6%);
+    background-color: contrast(@syntax-background-color, lighten(@syntax-background-color, 8%), darken(@syntax-background-color, 6%));
   }
 
 }

--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -42,9 +42,9 @@
   }
 
   h1 { font-size: 2.4em; font-weight: 300; }
-  h2 { font-size: 1.8em; font-weight: 300; }
-  h3 { font-size: 1.4em; font-weight: 400; }
-  h4 { font-size: 1.2em; font-weight: 500; }
+  h2 { font-size: 1.8em; font-weight: 400; }
+  h3 { font-size: 1.5em; font-weight: 500; }
+  h4 { font-size: 1.2em; font-weight: 600; }
   h5 { font-size: 1.1em; font-weight: 600; }
   h6 { font-size: 1.0em; font-weight: 600; }
 

--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -1,0 +1,154 @@
+
+// Default Markdown Preview styles
+
+// These are the default Markdown Preview styles.
+// They use the syntax-variables to adapt to the color scheme of syntax themes.
+
+
+@import "syntax-variables";
+
+.markdown-preview:not([data-use-github-style]) {
+  box-sizing: border-box;
+  padding: 2em;
+  font-size: 1.25em;
+  color: @syntax-text-color;
+  background-color: @syntax-background-color;
+  overflow: scroll;
+
+  code {
+    color: #333;
+  }
+
+  // Headings
+  h1, h2, h3, h4, h5, h6 {
+    -webkit-font-smoothing: antialiased;
+    cursor: text;
+  }
+
+  & > h1:first-child,
+  & > h1:first-child + h2,
+  & > h2:first-child,
+  & > h3:first-child,
+  & > h4:first-child,
+  & > h5:first-child,
+  & > h6:first-child {
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  a, a code {
+    color: #4183c4;
+  }
+
+  // fixes margin on shit like:
+  // <a name='the-heading'>
+  // <h1>The Heading</h1></a>
+  a:first-child {
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 0;
+      padding-top: 0;
+    }
+  }
+
+  h1 + p,
+  h2 + p,
+  h3 + p,
+  h4 + p,
+  h5 + p,
+  h6 + p {
+    margin-top: 0;
+  }
+
+  // ReST first graf in nested list
+  li p.first {
+    display: inline-block;
+  }
+
+  // Lists, Blockquotes & Such
+  ul,
+  ol {
+    li > :first-child,
+    li ul:first-of-type {
+      margin-top: 0;
+    }
+  }
+
+  ol > li {
+    list-style-type: decimal;
+  }
+
+  ul > li {
+    list-style-type: disc;
+  }
+
+  dl dt {
+    &:first-child {
+      padding: 0;
+    }
+
+    & > :first-child {
+      margin-top: 0;
+    }
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  dl dd {
+    & > :first-child {
+      margin-top: 0;
+    }
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  blockquote {
+    p {
+      font-size: 16px;
+      line-height: 1.5;
+    }
+  }
+
+  atom-text-editor {
+    padding: 16px;
+    overflow: auto;
+    font-size: 84%; // Hack to get default size to 13px.
+    line-height: 1.45;
+    background-color: @syntax-background-color;
+    border-radius: 3px;
+
+    // only show scrollbars on hover
+    .scrollbars-visible-always &::shadow {
+      .vertical-scrollbar,
+      .horizontal-scrollbar {
+        visibility: hidden;
+      }
+    }
+    .scrollbars-visible-always &:hover::shadow {
+      .vertical-scrollbar,
+      .horizontal-scrollbar {
+        visibility: visible;
+      }
+    }
+  }
+
+  atom-text-editor {
+    margin-bottom: 16px;
+    word-break: normal;
+  }
+
+  code,
+  tt,
+  atom-text-editor {
+    font-family: Consolas, "Liberation Mono", Courier, monospace;
+  }
+
+  .emoji {
+    height: 20px;
+    width: 20px;
+  }
+
+}

--- a/styles/markdown-preview-github.less
+++ b/styles/markdown-preview-github.less
@@ -22,6 +22,10 @@
   background-color: #fff;
   overflow: scroll;
 
+  a {
+    color: #337ab7;
+  }
+
   code {
     color: inherit;
   }

--- a/styles/markdown-preview-github.less
+++ b/styles/markdown-preview-github.less
@@ -21,7 +21,11 @@
   color: #333;
   background-color: #fff;
   overflow: scroll;
-  
+
+  code {
+    color: inherit;
+  }
+
   atom-text-editor {
     padding: .8em 1em;
     margin-bottom: 1em;

--- a/styles/markdown-preview-github.less
+++ b/styles/markdown-preview-github.less
@@ -16,7 +16,7 @@
 
   // The styles below override/complement the GitHub.com styles
   // It's needed because some markup or global styles are different
-  padding: @margin;
+  padding: 30px;
   font-size: 16px;
   color: #333;
   background-color: #fff;

--- a/styles/markdown-preview-github.less
+++ b/styles/markdown-preview-github.less
@@ -1,0 +1,32 @@
+
+// GitHub.com styles
+
+// These are the GitHub Flavored Markdown styles also found on github.com.
+// They can be anabled in the markdown-preview settings by turning on "Use GitHub.com styles".
+
+
+@import (reference) "../assets/primer-markdown";
+
+.markdown-preview[data-use-github-style] {
+
+  // Includes GitHub.com styles from `../assets/primer-markdown.less`.
+  // Source: https://github.com/primer/markdown/blob/master/components/markdown.scss
+  .markdown-body();
+
+
+  // The styles below override/complement the GitHub.com styles
+  // It's needed because some markup or global styles are different
+  padding: @margin;
+  font-size: 16px;
+  color: #333;
+  background-color: #fff;
+  overflow: scroll;
+  
+  atom-text-editor {
+    padding: .8em 1em;
+    margin-bottom: 1em;
+    font-size: .85em;
+    border-radius: 4px;
+    overflow: auto;
+  }
+}

--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -1,134 +1,8 @@
-@import "syntax-variables";
-@import (reference) "../assets/primer-markdown";
 
-.markdown-spinner {
-  margin: auto;
-  background-image: url(images/octocat-spinner-128.gif);
-  background-repeat: no-repeat;
-  background-size: 64px;
-  background-position: top center;
-  padding-top: 70px;
-  text-align: center;
-}
+// Global Markdown Preview styles
 
-// These are our overrides and specific styles built on top of GitHub's styling
-// of (GitHub Flavored) Markdown documents:
-//   * https://github.com/primer/markdown/blob/master/components/markdown.scss
-.markdown-preview,
-.markdown-preview[data-use-github-style] {
-  // This mixin comes from `../assets/primer-markdown.less`.
-  .markdown-body();
-
-  overflow: scroll;
-  background-color: #fff;
-  box-sizing: border-box;
-  padding: 20px;
-
-  &, code {
-    color: #333;
-  }
-
-  // Headings
-  h1, h2, h3, h4, h5, h6 {
-    -webkit-font-smoothing: antialiased;
-    cursor: text;
-  }
-
-  & > h1:first-child,
-  & > h1:first-child + h2,
-  & > h2:first-child,
-  & > h3:first-child,
-  & > h4:first-child,
-  & > h5:first-child,
-  & > h6:first-child {
-    margin-top: 0;
-    padding-top: 0;
-  }
-
-  a, a code {
-    color: #4183c4;
-  }
-
-  // fixes margin on shit like:
-  // <a name='the-heading'>
-  // <h1>The Heading</h1></a>
-  a:first-child {
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 0;
-      padding-top: 0;
-    }
-  }
-
-  h1 + p,
-  h2 + p,
-  h3 + p,
-  h4 + p,
-  h5 + p,
-  h6 + p {
-    margin-top: 0;
-  }
-
-  // ReST first graf in nested list
-  li p.first {
-    display: inline-block;
-  }
-
-  // Lists, Blockquotes & Such
-  ul,
-  ol {
-    li > :first-child,
-    li ul:first-of-type {
-      margin-top: 0;
-    }
-  }
-
-  ol > li {
-    list-style-type: decimal;
-  }
-
-  ul > li {
-    list-style-type: disc;
-  }
-
-  dl dt {
-    &:first-child {
-      padding: 0;
-    }
-
-    & > :first-child {
-      margin-top: 0;
-    }
-
-    & > :last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  dl dd {
-    & > :first-child {
-      margin-top: 0;
-    }
-
-    & > :last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  blockquote {
-    p {
-      font-size: 16px;
-      line-height: 1.5;
-    }
-  }
-
+.markdown-preview {
   atom-text-editor {
-    padding: @margin;
-    overflow: auto;
-    font-size: 84%; // Hack to get default size to 13px.
-    line-height: 1.45;
-    background-color: @syntax-background-color;
-    border-radius: 3px;
-
     // only show scrollbars on hover
     .scrollbars-visible-always &::shadow {
       .vertical-scrollbar,
@@ -143,20 +17,14 @@
       }
     }
   }
+}
 
-  atom-text-editor {
-    margin-bottom: @margin;
-    word-break: normal;
-  }
-
-  code,
-  tt,
-  atom-text-editor {
-    font-family: Consolas, "Liberation Mono", Courier, monospace;
-  }
-
-  .emoji {
-    height: 20px;
-    width: 20px;
-  }
+.markdown-spinner {
+  margin: auto;
+  background-image: url(images/octocat-spinner-128.gif);
+  background-repeat: no-repeat;
+  background-size: 64px;
+  background-position: top center;
+  padding-top: 70px;
+  text-align: center;
 }


### PR DESCRIPTION
This PR makes the Markdown Preview adapt to a syntax theme's color scheme.

#### Reasoning

- The old "default" and the "Use GitHub.com styles" are currently the same if a theme doesn't override it. This could make it a bit confusing why there is a toggle in the settings.
- The preview is less jarring when used with a dark theme
- Some UI/Syntax themes currently override markdown-preview, like the One themes do, but would be nice if not all themes need to override it themselves.

![screen shot 2015-09-02 at 7 56 57 pm](https://cloud.githubusercontent.com/assets/378023/9629606/e1de7682-51ae-11e5-97cb-b702ec6cb43b.png)
![screen shot 2015-09-02 at 7 58 34 pm](https://cloud.githubusercontent.com/assets/378023/9629605/e1d602e0-51ae-11e5-965d-4d5fd79ac498.png)
![screen shot 2015-09-02 at 8 01 14 pm](https://cloud.githubusercontent.com/assets/378023/9629604/e1d4482e-51ae-11e5-9bf4-40e30cb0f51c.png)

Closes #296 + #6