### PR TITLE
Add 'text.md' to default-grammars

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -34,6 +34,7 @@ module.exports =
         'text.html.basic'
         'text.plain'
         'text.plain.null-grammar'
+        'text.md'
       ]
       description: 'List of scopes for languages for which previewing is enabled. See [this README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language.'
     useGitHubStyle:


### PR DESCRIPTION
Concerning this issue: https://github.com/burodepeper/language-markdown/issues/51