### PR TITLE
Align list items containing checkboxes vertically

### DIFF
--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -88,9 +88,13 @@
   & > ul,
   & > ol {
     margin-bottom: @margin;
-  }
-  & > ol label, & > ul label {
-    vertical-align: top;
+    label {
+      vertical-align: top;
+      .task-list-item-checkbox {
+        margin: 0 0.15em 0.25em -1.4em;
+        vertical-align: middle;
+      }
+    }
   }
 
 

--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -89,6 +89,9 @@
   & > ol {
     margin-bottom: @margin;
   }
+  & > ol label, & > ul label {
+    vertical-align: top;
+  }
 
 
   // Blockquotes --------------------


### PR DESCRIPTION
As you can see in the screenshot below, list items that contains a checkbox doesn't render well. The bullet that stands on the left side of the list item is wrongly aligned to the bottom and causes confusion when you have multiple multi lined list items containing checkboxes.

This PR ensures the behavior described above does not occur anymore.

![captura de tela 2015-12-16 22 19 38](https://cloud.githubusercontent.com/assets/673884/11858941/da67959e-a444-11e5-9b04-eb501a0630d6.png)