### PR TITLE
Fix spelling error in Break on Single Newline setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -17,7 +17,7 @@ module.exports =
     breakOnSingleNewline:
       type: 'boolean'
       default: false
-      description: 'In Markdown, a single newline character doesn\'t cause a line break in the generated HTML. In GitHub Flavored Markdown, that is not true. Enable this config option to insert line breaks in redenred HTML for single newlines in Markdown source.'
+      description: 'In Markdown, a single newline character doesn\'t cause a line break in the generated HTML. In GitHub Flavored Markdown, that is not true. Enable this config option to insert line breaks in rendered HTML for single newlines in Markdown source.'
     liveUpdate:
       type: 'boolean'
       default: true


### PR DESCRIPTION
When viewing the settings for Markdown Preview, there is a spelling error in the **Break on Single Newline** option (cf. "redenred" HTML).

This misspelling is present in Markdown Preview v0.156.1 and Atom v1.3.2.

![settings](https://cloud.githubusercontent.com/assets/133372/11874302/34c3f152-a49c-11e5-9159-55e928a9084d.png)