### PR TITLE
Make Github style exactly(?) match actual Github.

### DIFF
--- a/styles/markdown-preview-github.less
+++ b/styles/markdown-preview-github.less
@@ -37,4 +37,37 @@
     border-radius: 4px;
     overflow: auto;
   }
+  
+  // Set to page to fixed width centered
+  width: 990px; // TODO: Where are the extra 10px coming from?
+  padding: 45px;
+  margin-left: auto;
+  margin-right: auto;
+
+  // Not sure if these are necessary...
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: rgb(221, 221, 221);
+  word-wrap: break-word;
+
+  // Fix styling for code blocks
+  code {
+    border: none;
+    color: black;
+    background-color: rgba(0,0,0,0.04);
+    font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
+  }
+  atom-text-editor {
+    border: none;
+    color: black;
+    background-color: #f7f7f7;
+    font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  }
+  atom-text-editor::shadow {
+    .invisible-character {
+      visibility: hidden;
+    }
+  }
 }


### PR DESCRIPTION
I'm trying to git the Github-style preview to exactly match the way Github renders README files. I don't know if you are interested, but here are some styles I added to my user "styles.less" that 
- set a fixed width to match Github.com
- fix the font and coloring on &lt;code&gt; tags and &lt;atom-text-editor&gt; to match Github.com

Feel free to include them, or ignore them, as you want!