### PR TITLE
Add configurable pane direction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Markdown Preview package [![Build Status](https://travis-ci.org/atom/markdown-preview.svg?branch=master)](https://travis-ci.org/atom/markdown-preview)
 
-Show the rendered HTML markdown to the right of the current editor using
-`ctrl-shift-m`.
+Show the rendered HTML markdown next to the the current editor using
+`ctrl-shift-m`.  You can choose in which direction to show the preview (`right`
+and `down` being the most common), or even to show the preview in a new tab in
+the current pane.
 
 It can be activated from the editor using the `ctrl-shift-m` key-binding and is
 currently enabled for `.markdown`, `.md`, `.mdown`, `.mkd`, `.mkdown`, `.ron`, and `.txt` files.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,6 +4,19 @@ fs = require 'fs-plus'
 MarkdownPreviewView = null # Defer until used
 renderer = null # Defer until used
 
+# Migrate any old openPreviewInSplitPane setting from a boolean to the new
+# string value.  The migration is 'false' --> 'none', and 'true' --> 'right'.
+# It would be nice to wait and do this on-demand, but config schema validation
+# runs even before the pacakge is activated, so we *have* to do this at module
+# load time if we want to accurately migrate the setting.
+atom.config.transact ->
+  splitKey = 'markdown-preview.openPreviewInSplitPane'
+  origSplit = atom.config.getRawValue(splitKey)
+  if origSplit? and typeof(origSplit) is 'boolean'
+    newSplit = if origSplit then 'right' else 'none'
+    console.log 'migrating', splitKey, 'from', origSplit, 'to', newSplit
+    atom.config.set(splitKey, newSplit)
+
 createMarkdownPreviewView = (state) ->
   MarkdownPreviewView ?= require './markdown-preview-view'
   new MarkdownPreviewView(state)
@@ -23,9 +36,10 @@ module.exports =
       default: true
       description: 'Re-render the preview as the contents of the source changes, without requiring the source buffer to be saved. If disabled, the preview is re-rendered only when the buffer is saved to disk.'
     openPreviewInSplitPane:
-      type: 'boolean'
-      default: true
-      description: 'Open the preview in a split pane. If disabled, the preview is opened in a new tab in the same pane.'
+      type: 'string'
+      default: 'right'
+      enum: ['none', 'right', 'down', 'left', 'up']
+      description: 'Where to open the preview, whether in a new tab in the same pane (`none`), or in a new pane in the specified direction.'
     grammars:
       type: 'array'
       default: [
@@ -116,8 +130,9 @@ module.exports =
     previousActivePane = atom.workspace.getActivePane()
     options =
       searchAllPanes: true
-    if atom.config.get('markdown-preview.openPreviewInSplitPane')
-      options.split = 'right'
+    splitPane = atom.config.get('markdown-preview.openPreviewInSplitPane')
+    if splitPane isnt 'none'
+      options.split = splitPane
     atom.workspace.open(uri, options).then (markdownPreviewView) ->
       if isMarkdownPreviewView(markdownPreviewView)
         previousActivePane.activate()


### PR DESCRIPTION
Addresses #99 and part of #328.  Does _not_ address any kind of "opposite" setting.

Migrates existing true/false (pane to the right or not) config settings into "right"/"none" equivalent value.

Note: In order to migrate an exiting setting, we have to run code very early when the module loads, _before_ it activates.  This is unfortunate from a performance standpoint.  If we're willing to simply lose any previous configuration setting (falling back to the default, "right"), we can avoid the perf impact of doing work during module load.  I'm completely open to the wisdom of the Atom community here; I just wanted to start with an already-backward-compatible option.