### PR TITLE
Fix issue #396

### DIFF
--- a/lib/extension-helper.coffee
+++ b/lib/extension-helper.coffee
@@ -36,4 +36,5 @@ scopesByFenceName =
 
 module.exports =
   scopeForFenceName: (fenceName) ->
+    fenceName = fenceName.toLowerCase()
     scopesByFenceName[fenceName] ? "source.#{fenceName}"

--- a/spec/fixtures/subdir/file.markdown
+++ b/spec/fixtures/subdir/file.markdown
@@ -2,6 +2,12 @@
 
 :cool:
 
+```
+function f(x) {
+  return x++;
+}
+```
+
 ```Ruby
 def func
   x = 1
@@ -11,12 +17,6 @@ end
 * ```javascript
 if a === 3 {
   b = 5
-}
-```
-
-```
-function f(x) {
-  return x++;
 }
 ```
 

--- a/spec/fixtures/subdir/file.markdown
+++ b/spec/fixtures/subdir/file.markdown
@@ -2,7 +2,7 @@
 
 :cool:
 
-```ruby
+```Ruby
 def func
   x = 1
 end


### PR DESCRIPTION
So that highlighting also works for capitalized fence names in the preview

![8b041f7b-cd0a-421f-9d0a-be9afa6dc8f8](https://cloud.githubusercontent.com/assets/18070858/15562302/ab13f2b8-2330-11e6-980d-65a05e8fb3b6.png)

We don't really need a new spec for this right?