### PR TITLE
Fix markdown-preview and emmet keybinding conflict

### DIFF
--- a/keymaps/markdown-preview.cson
+++ b/keymaps/markdown-preview.cson
@@ -1,4 +1,4 @@
-'atom-workspace, atom-workspace atom-text-editor':
+'atom-workspace atom-text-editor:not([mini])':
   'ctrl-M': 'markdown-preview:toggle'
 
 '.platform-darwin .markdown-preview':


### PR DESCRIPTION
Finish up the #239 pull request by making the required changes.
Resolves the `markdown-preview` and `emmet` packages keybinding conflict.
On OSX, the keybinding to activate `markdown-preview` is `ctrl-shift-m` while the [`emmet keybinding`](https://github.com/emmetio/emmet-atom/blob/master/keymaps/emmet.cson#L60)  can be activated by `cmd-shift-m`
