### PR TITLE
Use roaster 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fs-plus": "^2.0.0",
     "grim": "^1.2.1",
     "highlights": "^1.2",
-    "roaster": "^1.1.2",
+    "roaster": "^1.2.1",
     "temp": "^0.8.1",
     "underscore-plus": "^1.0.0",
     "wrench": "^1.5.0"


### PR DESCRIPTION
This change reduces the size of Atom.app by 7.5 MB. The version of js-yaml used in roaster 1.1.2 includes sample documents, one of which is very large. This has been resolved in newer versions of js-yaml, and the latest of these [is now included](https://github.com/gjtorikian/roaster/pull/20) in roaster 1.2.1.

Another significant size reduction in roaster can be claimed if you decide that the (now unmaintained and outdated) emoji-images package isn't worth the cost.