### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -4,13 +4,13 @@
 .markdown-preview {
   atom-text-editor {
     // only show scrollbars on hover
-    .scrollbars-visible-always &::shadow {
+    .scrollbars-visible-always {
       .vertical-scrollbar,
       .horizontal-scrollbar {
         visibility: hidden;
       }
     }
-    .scrollbars-visible-always &:hover::shadow {
+    .scrollbars-visible-always &:hover {
       .vertical-scrollbar,
       .horizontal-scrollbar {
         visibility: visible;

--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -4,7 +4,7 @@
 .markdown-preview {
   atom-text-editor {
     // only show scrollbars on hover
-    .scrollbars-visible-always {
+    .scrollbars-visible-always & {
       .vertical-scrollbar,
       .horizontal-scrollbar {
         visibility: hidden;


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai