### PR TITLE
Remove atom-space-pen-views

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -3,7 +3,6 @@ _ = require 'underscore-plus'
 cheerio = require 'cheerio'
 fs = require 'fs-plus'
 Highlights = require 'highlights'
-{$} = require 'atom-space-pen-views'
 roaster = null # Defer until used
 {scopeForFenceName} = require './extension-helper'
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "atom": "*"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.0",
     "cheerio": "0.15.0",
     "fs-plus": "^2.0.0",
     "highlights": "1.4.1",

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -3,7 +3,6 @@ fs = require 'fs-plus'
 temp = require 'temp'
 wrench = require 'wrench'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
-{$} = require 'atom-space-pen-views'
 
 describe "Markdown preview package", ->
   [workspaceElement, preview] = []

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -99,7 +99,7 @@ describe "Markdown preview package", ->
         markdownEditor.setText "Hey!"
 
         waitsFor ->
-          preview.text().indexOf("Hey!") >= 0
+          preview.element.textContent.includes('Hey!')
 
         runs ->
           expect(preview.showLoading).not.toHaveBeenCalled()
@@ -127,7 +127,7 @@ describe "Markdown preview package", ->
             markdownEditor.setText("Hey!")
 
           waitsFor ->
-            preview.text().indexOf("Hey!") >= 0
+            preview.element.textContent.includes("Hey!")
 
           runs ->
             expect(previewPane.isActive()).toBe true
@@ -148,7 +148,7 @@ describe "Markdown preview package", ->
             markdownEditor.setText("Hey!")
 
           waitsFor ->
-            preview.text().indexOf("Hey!") >= 0
+            preview.element.textContent.includes('Hey!')
 
           runs ->
             expect(editorPane.isActive()).toBe true
@@ -166,11 +166,11 @@ describe "Markdown preview package", ->
             didStopChangingHandler.callCount > 0
 
           runs ->
-            expect(preview.text()).not.toContain("ch ch changes")
+            expect(preview.element.textContent).not.toMatch("ch ch changes")
             atom.workspace.getActiveTextEditor().save()
 
           waitsFor ->
-            preview.text().indexOf("ch ch changes") >= 0
+            preview.element.textContent.includes("ch ch changes")
 
     describe "when the original preview is split", ->
       it "renders another preview in the new split pane", ->
@@ -213,7 +213,7 @@ describe "Markdown preview package", ->
           fs.writeFileSync(preview.getPath(), "Hey!")
 
         waitsFor "contents to update", ->
-          preview.text().indexOf("Hey!") >= 0
+          preview.element.textContent.includes('Hey!')
 
         runs ->
           expect(preview.showLoading).not.toHaveBeenCalled()
@@ -247,7 +247,7 @@ describe "Markdown preview package", ->
         """
 
         waitsFor "markdown to be rendered after its text changed", ->
-          preview.find("atom-text-editor").data("grammar") is "text plain null-grammar"
+          preview.element.querySelector("atom-text-editor").dataset.grammar is "text plain null-grammar"
 
         grammarAdded = false
         runs ->
@@ -260,7 +260,7 @@ describe "Markdown preview package", ->
         waitsFor "grammar to be added", -> grammarAdded
 
         waitsFor "markdown to be rendered after grammar was added", ->
-          preview.find("atom-text-editor").data("grammar") isnt "source js"
+          preview.element.querySelector("atom-text-editor").dataset.grammar isnt "source js"
 
   describe "when the markdown preview view is requested by file URI", ->
     it "opens a preview editor and watches the file for changes", ->
@@ -352,26 +352,27 @@ describe "Markdown preview package", ->
         runs ->
           workspaceElement = atom.views.getView(atom.workspace)
           atom.commands.dispatch workspaceElement, 'markdown-preview:copy-html'
-          preview = $('<div>').append(atom.clipboard.read())
+          preview = document.createElement('div')
+          preview.innerHTML = atom.clipboard.read()
 
       describe "when the code block's fence name has a matching grammar", ->
         it "tokenizes the code block with the grammar", ->
-          expect(preview.find("pre span.entity.name.function.ruby")).toExist()
+          expect(preview.querySelector("pre span.entity.name.function.ruby")).toBeDefined()
 
       describe "when the code block's fence name doesn't have a matching grammar", ->
         it "does not tokenize the code block", ->
-          expect(preview.find("pre.lang-kombucha .line .null-grammar").children().length).toBe 2
+          expect(preview.querySelectorAll("pre.lang-kombucha .line .null-grammar").length).toBe 2
 
       describe "when the code block contains empty lines", ->
         it "doesn't remove the empty lines", ->
-          expect(preview.find("pre.lang-python").children().length).toBe 6
-          expect(preview.find("pre.lang-python div:nth-child(2)").text().trim()).toBe ''
-          expect(preview.find("pre.lang-python div:nth-child(4)").text().trim()).toBe ''
-          expect(preview.find("pre.lang-python div:nth-child(5)").text().trim()).toBe ''
+          expect(preview.querySelector("pre.lang-python").children.length).toBe 6
+          expect(preview.querySelector("pre.lang-python div:nth-child(2)").textContent.trim()).toBe ''
+          expect(preview.querySelector("pre.lang-python div:nth-child(4)").textContent.trim()).toBe ''
+          expect(preview.querySelector("pre.lang-python div:nth-child(5)").textContent.trim()).toBe ''
 
       describe "when the code block is nested in a list", ->
         it "detects and styles the block", ->
-          expect(preview.find("pre.lang-javascript")).toHaveClass 'editor-colors'
+          expect(preview.querySelector("pre.lang-javascript")).toHaveClass 'editor-colors'
 
   describe "sanitization", ->
     it "removes script tags and attributes that commonly contain inline scripts", ->
@@ -380,7 +381,7 @@ describe "Markdown preview package", ->
       expectPreviewInSplitPane()
 
       runs ->
-        expect(preview[0].innerHTML).toBe """
+        expect(preview.element.innerHTML).toBe """
           <p>hello</p>
           <p></p>
           <p>
@@ -394,7 +395,7 @@ describe "Markdown preview package", ->
       expectPreviewInSplitPane()
 
       runs ->
-        expect(preview[0].innerHTML).toBe """
+        expect(preview.element.innerHTML).toBe """
           <p>content
           &lt;!doctype html&gt;</p>
         """
@@ -405,7 +406,7 @@ describe "Markdown preview package", ->
       runs -> atom.commands.dispatch workspaceElement, 'markdown-preview:toggle'
       expectPreviewInSplitPane()
 
-      runs -> expect(preview[0].innerHTML).toBe "content"
+      runs -> expect(preview.element.innerHTML).toBe "content"
 
   describe "when the markdown contains a <pre> tag", ->
     it "does not throw an exception", ->
@@ -413,7 +414,7 @@ describe "Markdown preview package", ->
       runs -> atom.commands.dispatch workspaceElement, 'markdown-preview:toggle'
       expectPreviewInSplitPane()
 
-      runs -> expect(preview.find('atom-text-editor')).toExist()
+      runs -> expect(preview.element.querySelector('atom-text-editor')).toBeDefined()
 
   describe "when there is an image with a relative path and no directory", ->
     it "does not alter the image src", ->
@@ -429,7 +430,7 @@ describe "Markdown preview package", ->
       expectPreviewInSplitPane()
 
       runs ->
-        expect(preview[0].innerHTML).toBe """
+        expect(preview.element.innerHTML).toBe """
           <p><img src="/foo.png" alt="rel path"></p>
         """
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 fs = require 'fs-plus'
 temp = require 'temp'
 MarkdownPreviewView = require '../lib/markdown-preview-view'
+url = require 'url'
 
 describe "MarkdownPreviewView", ->
   [file, preview, workspaceElement] = []
@@ -124,12 +125,12 @@ describe "MarkdownPreviewView", ->
     describe "when the image uses a relative path", ->
       it "resolves to a path relative to the file", ->
         image = preview.element.querySelector("img[alt=Image1]")
-        expect(image.src).toMatch atom.project.getDirectories()[0].resolve('subdir/image1.png')
+        expect(image.src).toMatch url.parse(atom.project.getDirectories()[0].resolve('subdir/image1.png'))
 
     describe "when the image uses an absolute path that does not exist", ->
       it "resolves to a path relative to the project root", ->
         image = preview.element.querySelector("img[alt=Image2]")
-        expect(image.src).toMatch atom.project.getDirectories()[0].resolve('tmp/image2.png')
+        expect(image.src).toMatch url.parse(atom.project.getDirectories()[0].resolve('tmp/image2.png'))
 
     describe "when the image uses an absolute path that exists", ->
       it "doesn't change the URL", ->
@@ -144,7 +145,7 @@ describe "MarkdownPreviewView", ->
           preview.renderMarkdown()
 
         runs ->
-          expect(preview.element.querySelector("img[alt=absolute]").src).toMatch filePath
+          expect(preview.element.querySelector("img[alt=absolute]").src).toMatch url.parse(filePath)
 
     describe "when the image uses a web URL", ->
       it "doesn't change the URL", ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -26,17 +26,17 @@ describe "MarkdownPreviewView", ->
   describe "::constructor", ->
     it "shows a loading spinner and renders the markdown", ->
       preview.showLoading()
-      expect(preview.find('.markdown-spinner')).toExist()
+      expect(preview.element.querySelector('.markdown-spinner')).toBeDefined()
 
       waitsForPromise ->
         preview.renderMarkdown()
 
       runs ->
-        expect(preview.find(".emoji")).toExist()
+        expect(preview.element.querySelector(".emoji")).toBeDefined()
 
     it "shows an error message when there is an error", ->
       preview.showError("Not a real file")
-      expect(preview.text()).toContain "Failed"
+      expect(preview.element.textContent).toMatch("Failed")
 
   describe "serialization", ->
     newPreview = null
@@ -83,15 +83,14 @@ describe "MarkdownPreviewView", ->
         preview.renderMarkdown()
 
     it "removes line decorations on rendered code blocks", ->
-      editor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
-      decorations = editor[0].getModel().getDecorations(class: 'cursor-line', type: 'line')
+      editor = preview.element.querySelector("atom-text-editor[data-grammar='text plain null-grammar']")
+      decorations = editor.getModel().getDecorations(class: 'cursor-line', type: 'line')
       expect(decorations.length).toBe 0
 
     describe "when the code block's fence name has a matching grammar", ->
       it "assigns the grammar on the atom-text-editor", ->
-        rubyEditor = preview.find("atom-text-editor[data-grammar='source ruby']")
-        expect(rubyEditor).toExist()
-        expect(rubyEditor[0].getModel().getText()).toBe """
+        rubyEditor = preview.element.querySelector("atom-text-editor[data-grammar='source ruby']")
+        expect(rubyEditor.getModel().getText()).toBe """
           def func
             x = 1
           end
@@ -99,9 +98,8 @@ describe "MarkdownPreviewView", ->
         """
 
         # nested in a list item
-        jsEditor = preview.find("atom-text-editor[data-grammar='source js']")
-        expect(jsEditor).toExist()
-        expect(jsEditor[0].getModel().getText()).toBe """
+        jsEditor = preview.element.querySelector("atom-text-editor[data-grammar='source js']")
+        expect(jsEditor.getModel().getText()).toBe """
           if a === 3 {
           b = 5
           }
@@ -110,9 +108,8 @@ describe "MarkdownPreviewView", ->
 
     describe "when the code block's fence name doesn't have a matching grammar", ->
       it "does not assign a specific grammar", ->
-        plainEditor = preview.find("atom-text-editor[data-grammar='text plain null-grammar']")
-        expect(plainEditor).toExist()
-        expect(plainEditor[0].getModel().getText()).toBe """
+        plainEditor = preview.element.querySelector("atom-text-editor[data-grammar='text plain null-grammar']")
+        expect(plainEditor.getModel().getText()).toBe """
           function f(x) {
             return x++;
           }
@@ -126,13 +123,13 @@ describe "MarkdownPreviewView", ->
 
     describe "when the image uses a relative path", ->
       it "resolves to a path relative to the file", ->
-        image = preview.find("img[alt=Image1]")
-        expect(image.attr('src')).toBe atom.project.getDirectories()[0].resolve('subdir/image1.png')
+        image = preview.element.querySelector("img[alt=Image1]")
+        expect(image.src).toMatch atom.project.getDirectories()[0].resolve('subdir/image1.png')
 
     describe "when the image uses an absolute path that does not exist", ->
       it "resolves to a path relative to the project root", ->
-        image = preview.find("img[alt=Image2]")
-        expect(image.attr('src')).toBe atom.project.getDirectories()[0].resolve('tmp/image2.png')
+        image = preview.element.querySelector("img[alt=Image2]")
+        expect(image.src).toMatch atom.project.getDirectories()[0].resolve('tmp/image2.png')
 
     describe "when the image uses an absolute path that exists", ->
       it "doesn't change the URL", ->
@@ -147,12 +144,12 @@ describe "MarkdownPreviewView", ->
           preview.renderMarkdown()
 
         runs ->
-          expect(preview.find("img[alt=absolute]").attr('src')).toBe filePath
+          expect(preview.element.querySelector("img[alt=absolute]").src).toMatch filePath
 
     describe "when the image uses a web URL", ->
       it "doesn't change the URL", ->
-        image = preview.find("img[alt=Image3]")
-        expect(image.attr('src')).toBe 'http://github.com/image3.png'
+        image = preview.element.querySelector("img[alt=Image3]")
+        expect(image.src).toBe 'http://github.com/image3.png'
 
   describe "gfm newlines", ->
     describe "when gfm newlines are not enabled", ->
@@ -163,7 +160,7 @@ describe "MarkdownPreviewView", ->
           preview.renderMarkdown()
 
         runs ->
-          expect(preview.find("p:last-child br").length).toBe 0
+          expect(preview.element.querySelectorAll("p:last-child br").length).toBe 0
 
     describe "when gfm newlines are enabled", ->
       it "creates a single paragraph with no <br>", ->
@@ -173,7 +170,7 @@ describe "MarkdownPreviewView", ->
           preview.renderMarkdown()
 
         runs ->
-          expect(preview.find("p:last-child br").length).toBe 1
+          expect(preview.element.querySelectorAll("p:last-child br").length).toBe 1
 
   describe "when core:save-as is triggered", ->
     beforeEach ->


### PR DESCRIPTION
This pull request contains an architectural change that replaces the usage of atom-space-pen-views with raw DOM APIs. As with other pull requests, there's a risk we might have introduced some regressions. @ungb: can you help me ensure this is not the case? Thanks! ✨ 