### PR TITLE
Fix scroll position when re-rendering markdown preview pane

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -172,6 +172,17 @@ class MarkdownPreviewView
 
       renderer.toHTML source, @getPath(), @getGrammar(), callback
 
+  syncScroll: ->
+    pane = atom.workspace.getActivePane()
+    if pane
+      editor = pane.getActiveEditor()
+    if editor
+      editorEle = atom.views.getView editor
+    pos = 0
+    if editorEle
+      pos = editorEle.getScrollTop()
+    @element.scrollTop = pos
+
   renderMarkdownText: (text) ->
     renderer.toDOMFragment text, @getPath(), @getGrammar(), (error, domFragment) =>
       if error
@@ -181,17 +192,7 @@ class MarkdownPreviewView
         @loaded = true
         @element.textContent = ''
         @element.appendChild(domFragment)
-
-        pane = atom.workspace.getActivePane()
-        if pane
-        	editor = pane.getActiveEditor()
-        if editor
-        	editorEle = atom.views.getView editor
-        pos = 0
-        if editorEle
-        	pos = editorEle.getScrollTop()
-        @element.scrollTop = pos
-
+        do this.syncScroll
         @emitter.emit 'did-change-markdown'
 
   getTitle: ->

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -181,6 +181,17 @@ class MarkdownPreviewView
         @loaded = true
         @element.textContent = ''
         @element.appendChild(domFragment)
+
+        pane = atom.workspace.getActivePane()
+        if pane
+        	editor = pane.getActiveEditor()
+        if editor
+        	editorEle = atom.views.getView editor
+        pos = 0
+        if editorEle
+        	pos = editorEle.getScrollTop()
+        @element.scrollTop = pos
+
         @emitter.emit 'did-change-markdown'
 
   getTitle: ->


### PR DESCRIPTION
### Requirements

* Any changes in mardown re-renders the markdown preview but does not preserve the scroll position. This PR aims to fix https://github.com/atom/markdown-preview/issues/24 and https://github.com/atom/markdown-preview/issues/370

### Description of the Change

This change involves finding the scrollTop position of editor element in which markdown is being edited and use that position to set scrollTop position on the markdown preview element.

## Alternate Designs

I also considered implementation like https://github.com/atom/markdown-preview/issues/370#issuecomment-268963044 but I think such a solution is over complicated and difficult to test. While the solution of this PR solves it for simple markdowns, I think it caters the 80%-20% principle and is a step forward. 

### Benefits

Resolves https://github.com/atom/markdown-preview/issues/24 and https://github.com/atom/markdown-preview/issues/370

### Possible Drawbacks

Does not solve 100% use case of the original issues. 

### Applicable Issues

https://github.com/atom/markdown-preview/issues/24
https://github.com/atom/markdown-preview/issues/370
