### PR TITLE
Fix zooming in/out when previewing markdown

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -103,23 +103,19 @@ class MarkdownPreviewView
     @disposables.add atom.grammars.onDidUpdateGrammar _.debounce((=> @renderMarkdown()), 250)
 
     atom.commands.add @element,
-      'core:move-up': =>
-        @scrollUp()
-      'core:move-down': =>
-        @scrollDown()
       'core:save-as': (event) =>
         event.stopPropagation()
         @saveAs()
       'core:copy': (event) =>
         event.stopPropagation() if @copyToClipboard()
       'markdown-preview:zoom-in': =>
-        zoomLevel = parseFloat(@css('zoom')) or 1
-        @css('zoom', zoomLevel + .1)
+        zoomLevel = parseFloat(getComputedStyle(@element).zoom)
+        @element.style.zoom = zoomLevel + 0.1
       'markdown-preview:zoom-out': =>
-        zoomLevel = parseFloat(@css('zoom')) or 1
-        @css('zoom', zoomLevel - .1)
+        zoomLevel = parseFloat(getComputedStyle(@element).zoom)
+        @element.style.zoom = zoomLevel - 0.1
       'markdown-preview:reset-zoom': =>
-        @css('zoom', 1)
+        @element.style.zoom = 1
 
     changeHandler = =>
       @renderMarkdown()

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -274,3 +274,17 @@ describe "MarkdownPreviewView", ->
          <pre class="editor-colors lang-javascript"><div class="line"><span class="syntax--source syntax--js"><span class="syntax--keyword syntax--control syntax--js"><span>if</span></span><span>&nbsp;a&nbsp;</span><span class="syntax--keyword syntax--operator syntax--comparison syntax--js"><span>===</span></span><span>&nbsp;</span><span class="syntax--constant syntax--numeric syntax--decimal syntax--js"><span>3</span></span><span>&nbsp;</span><span class="syntax--meta syntax--brace syntax--curly syntax--js"><span>{</span></span></span></div><div class="line"><span class="syntax--source syntax--js"><span>&nbsp;&nbsp;b&nbsp;</span><span class="syntax--keyword syntax--operator syntax--assignment syntax--js"><span>=</span></span><span>&nbsp;</span><span class="syntax--constant syntax--numeric syntax--decimal syntax--js"><span>5</span></span></span></div><div class="line"><span class="syntax--source syntax--js"><span class="syntax--meta syntax--brace syntax--curly syntax--js"><span>}</span></span></span></div></pre>
          <p>encoding \u2192 issue</p>
         """
+
+  describe "when markdown-preview:zoom-in or markdown-preview:zoom-out are triggered", ->
+    it "increases or decreases the zoom level of the markdown preview element", ->
+      jasmine.attachToDOM(preview.element)
+
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+      runs ->
+        originalZoomLevel = getComputedStyle(preview.element).zoom
+        atom.commands.dispatch(preview.element, 'markdown-preview:zoom-in')
+        expect(getComputedStyle(preview.element).zoom).toBeGreaterThan(originalZoomLevel)
+        atom.commands.dispatch(preview.element, 'markdown-preview:zoom-out')
+        expect(getComputedStyle(preview.element).zoom).toBe(originalZoomLevel)


### PR DESCRIPTION
Fixes #462.

This accidentally broke in the process of removing atom-space-pen-views in #456 and it's caused by a piece of code trying to use `MarkdownPreviewView` as a jQuery subclass.

This pull request fixes it and it also adds a regression test to ensure this behavior continues to work in the future.