### PR TITLE
fix preview typo

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -243,7 +243,7 @@ class MarkdownPreviewView
   showError: (result) ->
     @element.textContent = ''
     h2 = document.createElement('h2')
-    h2.textContent = 'Prevewing Markdown Failed'
+    h2.textContent = 'Previewing Markdown Failed'
     @element.appendChild(h2)
     if failureMessage = result?.message
       h3 = document.createElement('h3')


### PR DESCRIPTION
### Description of the Change

When a markdown preview fails, it displays a message. That message had a typo in it as seen in the following picture:

![screen shot 2017-02-13 at 2 36 08 pm](https://cloud.githubusercontent.com/assets/344114/22904496/f57326f6-f1f9-11e6-93b5-0982efd9bd84.png)

This change fixes "Prevewing" to "Previewing".