### PR TITLE
restore scrollTop of viewElement for smoother livereload

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -169,6 +169,7 @@ class MarkdownPreviewView
       renderer.toHTML source, @getPath(), @getGrammar(), callback
 
   renderMarkdownText: (text) ->
+    scrollTop = @element.scrollTop
     renderer.toDOMFragment text, @getPath(), @getGrammar(), (error, domFragment) =>
       if error
         @showError(error)
@@ -178,6 +179,7 @@ class MarkdownPreviewView
         @element.textContent = ''
         @element.appendChild(domFragment)
         @emitter.emit 'did-change-markdown'
+        @element.scrollTop = scrollTop
 
   getTitle: ->
     if @file? and @getPath()?

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -39,6 +39,21 @@ describe "MarkdownPreviewView", ->
       preview.showError("Not a real file")
       expect(preview.element.textContent).toMatch("Failed")
 
+    it "rerenders the markdown and the scrollTop stays the same", ->
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+      runs ->
+        preview.element.style.maxHeight = '10px'
+        preview.element.scrollTop = 24
+        expect(preview.element.scrollTop).toBe 24
+
+      waitsForPromise ->
+        preview.renderMarkdown()
+
+      runs ->
+        expect(preview.element.scrollTop).toBe 24
+
   describe "serialization", ->
     newPreview = null
 


### PR DESCRIPTION
### Requirements

- [x] Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
- [X] All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

When the PreviewView is reloaded after a change, the scrollTop is being reset to 0, which is quite annoying when writing a Markdown file while the view is scrolled to the current position.

With this Change the scrollTop will be restored after rerendering the PreviewView.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Smoother rerendering of the PreviewView with livereload.
Resolves https://github.com/atom/markdown-preview/issues/370

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues
https://github.com/atom/markdown-preview/issues/370

<!-- Enter any applicable Issues here -->