### PR TITLE
Destroy cursor line decoration layers in newer versions of the editor

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -116,11 +116,16 @@ convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
     preElement.remove()
 
     editor = editorElement.getModel()
-    # remove the default selection of a line in each editor
-    editor.getDecorations(class: 'cursor-line', type: 'line')[0].destroy()
     editor.setText(codeBlock.textContent)
     if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
       editor.setGrammar(grammar)
+
+    # Remove line decorations from code blocks.
+    if editor.cursorLineDecorations?
+      for cursorLineDecoration in editor.cursorLineDecorations
+        cursorLineDecoration.destroy()
+    else
+      editor.getDecorations(class: 'cursor-line', type: 'line')[0].destroy()
 
   domFragment
 


### PR DESCRIPTION
In https://github.com/atom/atom/pull/13880 we changed the way cursor lines are decorated, replacing the old per-line decorations with a decoration layer. With this pull request we are introducing a backward compatible change that destroys such decoration layers when rendering a code block, falling back to use `getDecorations` when `editor.cursorLineDecorations` is not present.

/cc: @nathansobo 