### PR TITLE
Fix relative image path resolution

### DIFF
--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -54,7 +54,9 @@ resolveImagePaths = (html, filePath) ->
   o = document.createElement('div')
   o.innerHTML = html
   for img in o.querySelectorAll('img')
-    if src = img.src
+    # We use the raw attribute instead of the .src property because the value
+    # of the property seems to be transformed in some cases.
+    if src = img.getAttribute('src')
       continue if src.match(/^(https?|atom):\/\//)
       continue if src.startsWith(process.resourcesPath)
       continue if src.startsWith(resourcePath)
@@ -63,9 +65,9 @@ resolveImagePaths = (html, filePath) ->
       if src[0] is '/'
         unless fs.isFileSync(src)
           if rootDirectory
-            src = path.join(rootDirectory, src.substring(1))
+            img.src = path.join(rootDirectory, src.substring(1))
       else
-        src = path.resolve(path.dirname(filePath), src)
+        img.src = path.resolve(path.dirname(filePath), src)
 
   o.innerHTML
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -140,7 +140,7 @@ describe "MarkdownPreviewView", ->
     describe "when the image uses a relative path", ->
       it "resolves to a path relative to the file", ->
         image = preview.element.querySelector("img[alt=Image1]")
-        expect(image.src).toMatch url.parse(atom.project.getDirectories()[0].resolve('subdir/image1.png'))
+        expect(image.getAttribute('src')).toBe atom.project.getDirectories()[0].resolve('subdir/image1.png')
 
     describe "when the image uses an absolute path that does not exist", ->
       it "resolves to a path relative to the project root", ->


### PR DESCRIPTION
Closes #505

It looks like a false positive in the tests for image resolution let a bug slip through in the replacement of Cheerio with raw DOM interaction. The only way to catch this would have been manual inspection. I've fixed the test to be more reliable.

/cc @damieng @ungb 