### PR TITLE
Code block maintenance updates

### DIFF
--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -105,6 +105,7 @@ class MarkdownPreviewView
     lazyRenderMarkdown = _.debounce((=> @renderMarkdown()), 250)
     @disposables.add atom.grammars.onDidAddGrammar -> lazyRenderMarkdown()
     @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
+    # TODO: Add atom.grammars.onDidRemoveGrammar when it exists
 
     atom.commands.add @element,
       'core:save-as': (event) =>

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -104,9 +104,11 @@ class MarkdownPreviewView
   handleEvents: ->
     lazyRenderMarkdown = _.debounce((=> @renderMarkdown()), 250)
     @disposables.add atom.grammars.onDidAddGrammar -> lazyRenderMarkdown()
-    @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
-    # TODO: Add atom.grammars.onDidRemoveGrammar when it exists
-    # https://github.com/atom/first-mate/issues/103
+    if typeof atom.grammars.onDidRemoveGrammar is 'function'
+      @disposables.add atom.grammars.onDidRemoveGrammar -> lazyRenderMarkdown()
+    else
+      # TODO: Remove onDidUpdateGrammar hook once onDidRemoveGrammar is released
+      @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
 
     atom.commands.add @element,
       'core:save-as': (event) =>

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -106,6 +106,7 @@ class MarkdownPreviewView
     @disposables.add atom.grammars.onDidAddGrammar -> lazyRenderMarkdown()
     @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
     # TODO: Add atom.grammars.onDidRemoveGrammar when it exists
+    # https://github.com/atom/first-mate/issues/103
 
     atom.commands.add @element,
       'core:save-as': (event) =>

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -102,8 +102,9 @@ class MarkdownPreviewView
     null
 
   handleEvents: ->
-    @disposables.add atom.grammars.onDidAddGrammar => _.debounce((=> @renderMarkdown()), 250)
-    @disposables.add atom.grammars.onDidUpdateGrammar _.debounce((=> @renderMarkdown()), 250)
+    lazyRenderMarkdown = _.debounce((=> @renderMarkdown()), 250)
+    @disposables.add atom.grammars.onDidAddGrammar -> lazyRenderMarkdown()
+    @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
 
     atom.commands.add @element,
       'core:save-as': (event) =>

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -9,8 +9,6 @@ roaster = null # Defer until used
 highlighter = null
 {resourcePath} = atom.getLoadSettings()
 packagePath = path.dirname(__dirname)
-codeBlocks = new Map()
-grammarSubscription = null
 
 exports.toDOMFragment = (text='', filePath, grammar, callback) ->
   render text, filePath, (error, html) ->
@@ -73,13 +71,6 @@ resolveImagePaths = (html, filePath) ->
   o.innerHTML
 
 convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
-  codeBlocks.clear()
-  grammarSubscription?.dispose()
-  grammarSubscription = atom.grammars.onDidAddGrammar ->
-    codeBlocks.forEach (fenceName, editor) ->
-      if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
-        editor.setGrammar(grammar)
-
   if fontFamily = atom.config.get('editor.fontFamily')
     for codeElement in domFragment.querySelectorAll('code')
       codeElement.style.fontFamily = fontFamily
@@ -105,8 +96,6 @@ convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
     # Remove line decorations from code blocks.
     for cursorLineDecoration in editor.cursorLineDecorations
       cursorLineDecoration.destroy()
-
-    codeBlocks.set(editor, fenceName)
 
   domFragment
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -1,5 +1,4 @@
 path = require 'path'
-_ = require 'underscore-plus'
 cheerio = require 'cheerio'
 createDOMPurify = require 'dompurify'
 fs = require 'fs-plus'
@@ -10,6 +9,8 @@ roaster = null # Defer until used
 highlighter = null
 {resourcePath} = atom.getLoadSettings()
 packagePath = path.dirname(__dirname)
+codeBlocks = new Map()
+grammarSubscription = null
 
 exports.toDOMFragment = (text='', filePath, grammar, callback) ->
   render text, filePath, (error, html) ->
@@ -72,8 +73,14 @@ resolveImagePaths = (html, filePath) ->
   o.innerHTML
 
 convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
-  if fontFamily = atom.config.get('editor.fontFamily')
+  codeBlocks.clear()
+  grammarSubscription?.dispose()
+  grammarSubscription = atom.grammars.onDidAddGrammar ->
+    codeBlocks.forEach (fenceName, editor) ->
+      if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
+        editor.setGrammar(grammar)
 
+  if fontFamily = atom.config.get('editor.fontFamily')
     for codeElement in domFragment.querySelectorAll('code')
       codeElement.style.fontFamily = fontFamily
 
@@ -82,23 +89,24 @@ convertCodeBlocksToAtomEditors = (domFragment, defaultLanguage='text') ->
     fenceName = codeBlock.getAttribute('class')?.replace(/^lang-/, '') ? defaultLanguage
 
     editorElement = document.createElement('atom-text-editor')
-    editorElement.setAttributeNode(document.createAttribute('gutter-hidden'))
-    editorElement.removeAttribute('tabindex') # make read-only
 
     preElement.parentNode.insertBefore(editorElement, preElement)
     preElement.remove()
 
     editor = editorElement.getModel()
-    editor.setText(codeBlock.textContent)
+    lastNewlineIndex = codeBlock.textContent.search(/\r?\n$/)
+    editor.setText(codeBlock.textContent.substring(0, lastNewlineIndex)) # Do not include a trailing newline
+    editorElement.setAttributeNode(document.createAttribute('gutter-hidden')) # Hide gutter
+    editorElement.removeAttribute('tabindex') # Make read-only
+
     if grammar = atom.grammars.grammarForScopeName(scopeForFenceName(fenceName))
       editor.setGrammar(grammar)
 
     # Remove line decorations from code blocks.
-    if editor.cursorLineDecorations?
-      for cursorLineDecoration in editor.cursorLineDecorations
-        cursorLineDecoration.destroy()
-    else
-      editor.getDecorations(class: 'cursor-line', type: 'line')[0].destroy()
+    for cursorLineDecoration in editor.cursorLineDecorations
+      cursorLineDecoration.destroy()
+
+    codeBlocks.set(editor, fenceName)
 
   domFragment
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -110,7 +110,6 @@ describe "MarkdownPreviewView", ->
           def func
             x = 1
           end
-
         """
 
         # nested in a list item
@@ -119,7 +118,6 @@ describe "MarkdownPreviewView", ->
           if a === 3 {
           b = 5
           }
-
         """
 
     describe "when the code block's fence name doesn't have a matching grammar", ->
@@ -129,7 +127,6 @@ describe "MarkdownPreviewView", ->
           function f(x) {
             return x++;
           }
-
         """
 
   describe "image resolving", ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -8,6 +8,9 @@ describe "MarkdownPreviewView", ->
   [file, preview, workspaceElement] = []
 
   beforeEach ->
+    # Makes _.debounce work
+    jasmine.useRealClock()
+
     filePath = atom.project.getDirectories()[0].resolve('subdir/file.markdown')
     preview = new MarkdownPreviewView({filePath})
     jasmine.attachToDOM(preview.element)
@@ -135,7 +138,14 @@ describe "MarkdownPreviewView", ->
 
     describe "when an editor cannot find the grammar that is later loaded", ->
       it "updates the editor grammar", ->
-        renderSpy = spyOn(preview, 'renderMarkdown').andCallThrough()
+        renderSpy = null
+
+        # FIXME: This is a temporary hack until atom.grammars.onDidRemoveGrammar exists
+        waitsForPromise ->
+          atom.packages.activatePackage('language-gfm')
+
+        runs ->
+          renderSpy = spyOn(preview, 'renderMarkdown').andCallThrough()
 
         waitsForPromise ->
           atom.packages.deactivatePackage('language-ruby')

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -135,11 +135,13 @@ describe "MarkdownPreviewView", ->
 
     describe "when an editor cannot find the grammar that is later loaded", ->
       it "updates the editor grammar", ->
+        renderSpy = spyOn(preview, 'renderMarkdown').andCallThrough()
+
         waitsForPromise ->
           atom.packages.deactivatePackage('language-ruby')
 
-        waitsForPromise ->
-          preview.renderMarkdown()
+        waitsFor 'renderMarkdown to be called after disabling a language', ->
+          renderSpy.callCount is 1
 
         runs ->
           rubyEditor = preview.element.querySelector("atom-text-editor[data-grammar='source ruby']")
@@ -148,8 +150,8 @@ describe "MarkdownPreviewView", ->
         waitsForPromise ->
           atom.packages.activatePackage('language-ruby')
 
-        waitsForPromise ->
-          preview.renderMarkdown()
+        waitsFor 'renderMarkdown to be called after enabling a language', ->
+          renderSpy.callCount is 2
 
         runs ->
           rubyEditor = preview.element.querySelector("atom-text-editor[data-grammar='source ruby']")

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -129,6 +129,32 @@ describe "MarkdownPreviewView", ->
           }
         """
 
+    describe "when an editor cannot find the grammar that is later loaded", ->
+      it "updates the editor grammar", ->
+        waitsForPromise ->
+          atom.packages.deactivatePackage('language-ruby')
+
+        waitsForPromise ->
+          preview.renderMarkdown()
+
+        runs ->
+          rubyEditor = preview.element.querySelector("atom-text-editor[data-grammar='source ruby']")
+          expect(rubyEditor).toBeNull()
+
+        waitsForPromise ->
+          atom.packages.activatePackage('language-ruby')
+
+        waitsForPromise ->
+          preview.renderMarkdown()
+
+        runs ->
+          rubyEditor = preview.element.querySelector("atom-text-editor[data-grammar='source ruby']")
+          expect(rubyEditor.getModel().getText()).toBe """
+            def func
+              x = 1
+            end
+          """
+
   describe "image resolving", ->
     beforeEach ->
       waitsForPromise ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -103,6 +103,10 @@ describe "MarkdownPreviewView", ->
       decorations = editor.getModel().getDecorations(class: 'cursor-line', type: 'line')
       expect(decorations.length).toBe 0
 
+    it "sets the editors as read-only", ->
+      preview.element.querySelectorAll("atom-text-editor").forEach (editorElement) ->
+        expect(editorElement.getAttribute('tabindex')).toBeNull()
+
     describe "when the code block's fence name has a matching grammar", ->
       it "assigns the grammar on the atom-text-editor", ->
         rubyEditor = preview.element.querySelector("atom-text-editor[data-grammar='source ruby']")

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -141,6 +141,7 @@ describe "MarkdownPreviewView", ->
         renderSpy = null
 
         # FIXME: This is a temporary hack until atom.grammars.onDidRemoveGrammar exists
+        # https://github.com/atom/first-mate/issues/103
         waitsForPromise ->
           atom.packages.activatePackage('language-gfm')
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -140,10 +140,10 @@ describe "MarkdownPreviewView", ->
       it "updates the editor grammar", ->
         renderSpy = null
 
-        # FIXME: This is a temporary hack until atom.grammars.onDidRemoveGrammar exists
-        # https://github.com/atom/first-mate/issues/103
-        waitsForPromise ->
-          atom.packages.activatePackage('language-gfm')
+        unless typeof atom.grammars.onDidRemoveGrammar is 'function'
+          # TODO: Remove once atom.grammars.onDidRemoveGrammar is released
+          waitsForPromise ->
+            atom.packages.activatePackage('language-gfm')
 
         runs ->
           renderSpy = spyOn(preview, 'renderMarkdown').andCallThrough()


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

1. Remove unused underscore-plus require
2. Actually remove the tabindex attribute so that the code block is un-editable.  This was done previously but it turned out that getting the model of the editor added it back.  So now we remove it after retrieving the model.
3. Do not render the last trailing newline of a code block.
4. Fix debouncing of Markdown rendering when receiving grammar update events.

### Alternate Designs

N/A

### Benefits

Typing isn't allowed in code blocks anymore, and the last newline is removed as expected.  If the preview is loaded before grammar packages finish loading, it'll receive proper tokenization once they do.

### Possible Drawbacks

Hopefully none.

### Applicable Issues

Supersedes and closes #425, which could have potentially left `\r` in the code block.
Fixes #479
Fixes #491