### PR TITLE
Improve native commands

### DIFF
--- a/keymaps/markdown-preview.cson
+++ b/keymaps/markdown-preview.cson
@@ -2,6 +2,7 @@
   'ctrl-shift-m': 'markdown-preview:toggle'
 
 '.platform-darwin .markdown-preview':
+  'cmd-a': 'markdown-preview:select-all'
   'cmd-+': 'markdown-preview:zoom-in'
   'cmd-=': 'markdown-preview:zoom-in'
   'cmd--': 'markdown-preview:zoom-out'
@@ -9,6 +10,7 @@
   'cmd-0': 'markdown-preview:reset-zoom'
 
 '.platform-win32 .markdown-preview, .platform-linux .markdown-preview':
+  'ctrl-a': 'markdown-preview:select-all'
   'ctrl-+': 'markdown-preview:zoom-in'
   'ctrl-=': 'markdown-preview:zoom-in'
   'ctrl--': 'markdown-preview:zoom-out'

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -111,10 +111,10 @@ class MarkdownPreviewView
       @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
 
     atom.commands.add @element,
-      'core:save-as': =>
+      'core:save-as': (event) =>
         event.stopPropagation()
         @saveAs()
-      'core:copy': =>
+      'core:copy': (event) =>
         event.stopPropagation()
         @copyToClipboard()
       'markdown-preview:select-all': =>

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -13,7 +13,7 @@ class MarkdownPreviewView
 
   constructor: ({@editorId, @filePath}) ->
     @element = document.createElement('div')
-    @element.classList.add('markdown-preview', 'native-key-bindings')
+    @element.classList.add('markdown-preview')
     @element.tabIndex = -1
     @emitter = new Emitter
     @loaded = false
@@ -111,11 +111,12 @@ class MarkdownPreviewView
       @disposables.add atom.grammars.onDidUpdateGrammar -> lazyRenderMarkdown()
 
     atom.commands.add @element,
-      'core:save-as': (event) =>
+      'core:save-as': =>
         event.stopPropagation()
         @saveAs()
-      'core:copy': (event) =>
-        event.stopPropagation() if @copyToClipboard()
+      'core:copy': =>
+        event.stopPropagation()
+        @copyToClipboard()
       'markdown-preview:zoom-in': =>
         zoomLevel = parseFloat(getComputedStyle(@element).zoom)
         @element.style.zoom = zoomLevel + 0.1
@@ -269,22 +270,21 @@ class MarkdownPreviewView
     @element.appendChild(div)
 
   copyToClipboard: ->
-    return false if @loading
+    return if @loading
 
     selection = window.getSelection()
     selectedText = selection.toString()
     selectedNode = selection.baseNode
 
     # Use default copy event handler if there is selected text inside this view
-    return false if selectedText and selectedNode? and (@element is selectedNode or @element.contains(selectedNode))
-
-    @getHTML (error, html) ->
-      if error?
-        console.warn('Copying Markdown as HTML failed', error)
-      else
-        atom.clipboard.write(html)
-
-    true
+    if selectedText and selectedNode? and (@element is selectedNode or @element.contains(selectedNode))
+      atom.clipboard.write(selectedText)
+    else
+      @getHTML (error, html) ->
+        if error?
+          console.warn('Copying Markdown as HTML failed', error)
+        else
+          atom.clipboard.write(html)
 
   saveAs: ->
     return if @loading

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -293,7 +293,7 @@ class MarkdownPreviewView
     else
       @getHTML (error, html) ->
         if error?
-          console.warn('Copying Markdown as HTML failed', error)
+          atom.notifications.addError('Copying Markdown as HTML failed', {dismissable: true, detail: error.message})
         else
           atom.clipboard.write(html)
 
@@ -314,9 +314,8 @@ class MarkdownPreviewView
 
       @getHTML (error, htmlBody) =>
         if error?
-          console.warn('Saving Markdown as HTML failed', error)
+          atom.notifications.addError('Saving Markdown as HTML failed', {dismissable: true, detail: error.message})
         else
-
           html = """
             <!DOCTYPE html>
             <html>

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -154,6 +154,15 @@ class MarkdownPreviewView
       else
         @element.removeAttribute('data-use-github-style')
 
+    document.onselectionchange = =>
+      selection = window.getSelection()
+      selectedNode = selection.baseNode
+      if @element is selectedNode or @element.contains(selectedNode)
+        if selection.isCollapsed
+          @element.classList.remove('has-selection')
+        else
+          @element.classList.add('has-selection')
+
   renderMarkdown: ->
     @showLoading() unless @loaded
     @getMarkdownSource()

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -117,6 +117,8 @@ class MarkdownPreviewView
       'core:copy': =>
         event.stopPropagation()
         @copyToClipboard()
+      'markdown-preview:select-all': =>
+        @selectAll()
       'markdown-preview:zoom-in': =>
         zoomLevel = parseFloat(getComputedStyle(@element).zoom)
         @element.style.zoom = zoomLevel + 0.1
@@ -268,6 +270,15 @@ class MarkdownPreviewView
     div.classList.add('markdown-spinner')
     div.textContent = 'Loading Markdown\u2026'
     @element.appendChild(div)
+
+  selectAll: ->
+    return if @loading
+
+    selection = window.getSelection()
+    selection.removeAllRanges()
+    range = document.createRange()
+    range.selectNode(@element)
+    selection.addRange(range)
 
   copyToClipboard: ->
     return if @loading

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -286,7 +286,7 @@ class MarkdownPreviewView
     selection = window.getSelection()
     selection.removeAllRanges()
     range = document.createRange()
-    range.selectNode(@element)
+    range.selectNodeContents(@element)
     selection.addRange(range)
 
   copyToClipboard: ->

--- a/menus/markdown-preview.cson
+++ b/menus/markdown-preview.cson
@@ -11,6 +11,7 @@
 
 'context-menu':
   '.markdown-preview': [
+    {label: 'Select All', command: 'markdown-preview:select-all'}
     {label: 'Save As HTML\u2026', command: 'core:save-as'}
   ]
   '.markdown-preview.has-selection': [

--- a/menus/markdown-preview.cson
+++ b/menus/markdown-preview.cson
@@ -11,20 +11,25 @@
 
 'context-menu':
   '.markdown-preview': [
-    {label: 'Copy As HTML', command: 'core:copy'}
     {label: 'Save As HTML\u2026', command: 'core:save-as'}
   ]
+  '.markdown-preview.has-selection': [
+    {label: 'Copy', command: 'core:copy'}
+  ]
+  '.markdown-preview:not(.has-selection)': [
+    {label: 'Copy As HTML', command: 'core:copy'}
+  ]
   '.tree-view .file .name[data-name$=\\.markdown]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]
   '.tree-view .file .name[data-name$=\\.md]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]
   '.tree-view .file .name[data-name$=\\.mdown]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]
   '.tree-view .file .name[data-name$=\\.mkd]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]
   '.tree-view .file .name[data-name$=\\.mkdown]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]
   '.tree-view .file .name[data-name$=\\.ron]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]
   '.tree-view .file .name[data-name$=\\.txt]':
-    [{label: 'Markdown Preview', command:  'markdown-preview:preview-file'}]
+    [{label: 'Markdown Preview', command: 'markdown-preview:preview-file'}]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Remove `native-key-bindings` class from Markdown Preview to give us finer control over `core:copy`
* When there is a selection, `core:copy` copies the selected text
  * Context menu reads "Copy"
* When there isn't a selection, `core:copy` copies the Markdown as HTML
  * Context menu reads "Copy as HTML"
* A new `markdown-preview:select-all` command has been added that does pretty much what you expect it to do
* `console.warn`s have been changed to Notifications, though I also highly doubt that those will ever be encountered

### Alternate Designs

None.

### Benefits

* Less confusion over `core:copy`
* A convenient away to select all

### Possible Drawbacks

The Selection APIs are a bit weird.  I ended up having to add `onselectionchange` to `document` because that's the only place where events are emitted.  I don't think it'll be a performance problem though.
I also have to look into some potential select-all wonkiness when there's a selection elsewhere.

### Applicable Issues

Closes #251
Fixes #259
Fixes #257