### PR TITLE
Add disposables

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,8 +28,6 @@ module.exports =
 
     previewFile = @previewFile.bind(this)
     for extension in ['markdown', 'md', 'mdown', 'mkd', 'mkdown', 'ron', 'txt']
-      # FIXME: This doesn't work. Individual elements in the Tree View do not get focus
-      # so this selector never matches.
       @disposables.add atom.commands.add ".tree-view .file .name[data-name$=\\.#{extension}]",
         'markdown-preview:preview-file', previewFile
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -250,8 +250,6 @@ describe "MarkdownPreviewView", ->
 
   describe "text selections", ->
     it "adds the `has-selection` class to the preview depending on if there is a text selection", ->
-      selectionSpy = spyOn(document, 'onselectionchange').andCallThrough()
-
       expect(preview.element.classList.contains('has-selection')).toBe false
 
       selection = window.getSelection()
@@ -259,18 +257,13 @@ describe "MarkdownPreviewView", ->
       selection.selectAllChildren(document.querySelector('atom-text-editor'))
 
       waitsFor ->
-        selectionSpy.callCount is 1
+        preview.element.classList.contains('has-selection') is true
 
       runs ->
-        expect(preview.element.classList.contains('has-selection')).toBe true
-
         selection.removeAllRanges()
 
       waitsFor ->
-        selectionSpy.callCount is 2
-
-      runs ->
-        expect(preview.element.classList.contains('has-selection')).toBe false
+        preview.element.classList.contains('has-selection') is false
 
   describe "when core:save-as is triggered", ->
     beforeEach ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Properly clean up after ourselves when disabled.

### Alternate Designs

None.

### Benefits

Better deactivation process.  Previously after disabling markdown-preview the commands would stick around in the command palette.

### Possible Drawbacks

None.

### Applicable Issues

N/A