### PR TITLE
Use atom.packages.hasActivatedInitialPackages

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,3 @@
-url = require 'url'
 fs = require 'fs-plus'
 {CompositeDisposable} = require 'atom'
 

--- a/lib/markdown-preview-view.coffee
+++ b/lib/markdown-preview-view.coffee
@@ -21,7 +21,7 @@ class MarkdownPreviewView
     @registerScrollCommands()
     if @editorId?
       @resolveEditor(@editorId)
-    else if atom.workspace?
+    else if atom.packages.hasActivatedInitialPackages()
       @subscribeToFilePath(@filePath)
     else
       @disposables.add atom.packages.onDidActivateInitialPackages =>
@@ -75,7 +75,7 @@ class MarkdownPreviewView
   subscribeToFilePath: (filePath) ->
     @file = new File(filePath)
     @emitter.emit 'did-change-title'
-    @disposables.add @file.onDidRename(=> @emitter.emit 'did-change-title')
+    @disposables.add @file.onDidRename => @emitter.emit 'did-change-title'
     @handleEvents()
     @renderMarkdown()
 
@@ -85,13 +85,13 @@ class MarkdownPreviewView
 
       if @editor?
         @emitter.emit 'did-change-title'
-        @disposables.add @editor.onDidDestroy(=> @subscribeToFilePath(@getPath()))
+        @disposables.add @editor.onDidDestroy => @subscribeToFilePath(@getPath())
         @handleEvents()
         @renderMarkdown()
       else
         @subscribeToFilePath(@filePath)
 
-    if atom.workspace?
+    if atom.packages.hasActivatedInitialPackages()
       resolve()
     else
       @disposables.add atom.packages.onDidActivateInitialPackages(resolve)

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -21,6 +21,9 @@ describe "Markdown Preview", ->
     waitsForPromise ->
       atom.packages.activatePackage('language-gfm')
 
+    runs ->
+      spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn true
+
   expectPreviewInSplitPane = ->
     waitsFor -> atom.workspace.getCenter().getPanes().length is 2
 

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -11,6 +11,8 @@ describe "MarkdownPreviewView", ->
     # Makes _.debounce work
     jasmine.useRealClock()
 
+    spyOn(atom.packages, 'hasActivatedInitialPackages').andReturn true
+
     filePath = atom.project.getDirectories()[0].resolve('subdir/file.markdown')
     preview = new MarkdownPreviewView({filePath})
     jasmine.attachToDOM(preview.element)


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I assume that the point of the `atom.workspace?` check was to try to wait until Atom was done loading before checking for text editors.  However, the workspace may be loaded before text editors are deserialized.  Therefore I rely on `atom.packages.hasActivatedInitialPackages`, which is the same thing that would happen if `atom.workspace` did not exist.  This means that when reloading or closing/reopening Atom with a Markdown Preview open, the preview will continue to live update as it can find its existing editor.  Before, it would become orphaned and rely on the backup file system events instead (due to `atom.workspace.getTextEditors()` being an empty array on startup).

### Alternate Designs

Relying on package activation seems a bit weird.  However, there doesn't seem to be a way to get whether the workspace has fully loaded or not, so this seems like a good alternative.

### Benefits

Less cases of unnecessary preview orphanage.

### Possible Drawbacks

None.

### Applicable Issues

N/A

I wasn't able to test for this because I had to globally spy on `atom.packages.hasActivatedInitialPackages`, and also because the only way to truly test this would be to simulate an entire Atom restart.