### PR TITLE
Do not hijack core:save-as

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -125,9 +125,9 @@ module.exports =
         atom.clipboard.write(html)
 
   saveAsHTML: ->
-    activePane = atom.workspace.getActivePaneItem()
-    if isMarkdownPreviewView(activePane)
-      activePane.saveAs()
+    activePaneItem = atom.workspace.getActivePaneItem()
+    if isMarkdownPreviewView(activePaneItem)
+      atom.workspace.getActivePane().saveItemAs(activePaneItem)
       return
 
     editor = atom.workspace.getActiveTextEditor()
@@ -138,12 +138,7 @@ module.exports =
 
     uri = @uriForEditor(editor)
     markdownPreviewPane = atom.workspace.paneForURI(uri)
-    return unless markdownPreviewPane?
+    markdownPreviewPaneItem = markdownPreviewPane?.itemForURI(uri)
 
-    previousActivePane = atom.workspace.getActivePane()
-    markdownPreviewPane.activate()
-    activePane = atom.workspace.getActivePaneItem()
-
-    if isMarkdownPreviewView(activePane)
-      activePane.saveAs().then ->
-        previousActivePane.activate()
+    if isMarkdownPreviewView(markdownPreviewPaneItem)
+      markdownPreviewPane.saveItemAs(markdownPreviewPaneItem)

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -508,7 +508,11 @@ describe "Markdown Preview", ->
 
       runs ->
         spyOn(preview, 'getSaveDialogOptions').andReturn({defaultPath: outputPath})
-        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake((options, callback) -> callback(options.defaultPath))
+        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake (options, callback) ->
+          callback?(options.defaultPath)
+          # TODO: When https://github.com/atom/atom/pull/16245 lands remove the return
+          # and the existence check on the callback
+          return options.defaultPath
         atom.commands.dispatch atom.workspace.getActiveTextEditor().getElement(), 'markdown-preview:save-as-html'
 
       waitsFor ->
@@ -526,7 +530,11 @@ describe "Markdown Preview", ->
 
       runs ->
         spyOn(preview, 'getSaveDialogOptions').andReturn({defaultPath: outputPath})
-        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake((options, callback) -> callback(options.defaultPath))
+        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake (options, callback) ->
+          callback?(options.defaultPath)
+          # TODO: When https://github.com/atom/atom/pull/16245 lands remove the return
+          # and the existence check on the callback
+          return options.defaultPath
         atom.commands.dispatch editorPane.getActiveItem().getElement(), 'markdown-preview:save-as-html'
 
       waitsFor ->

--- a/spec/markdown-preview-spec.coffee
+++ b/spec/markdown-preview-spec.coffee
@@ -507,7 +507,8 @@ describe "Markdown Preview", ->
       expect(fs.existsSync(outputPath)).toBe false
 
       runs ->
-        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        spyOn(preview, 'getSaveDialogOptions').andReturn({defaultPath: outputPath})
+        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake((options, callback) -> callback(options.defaultPath))
         atom.commands.dispatch atom.workspace.getActiveTextEditor().getElement(), 'markdown-preview:save-as-html'
 
       waitsFor ->
@@ -524,7 +525,8 @@ describe "Markdown Preview", ->
       expect(fs.existsSync(outputPath)).toBe false
 
       runs ->
-        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        spyOn(preview, 'getSaveDialogOptions').andReturn({defaultPath: outputPath})
+        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake((options, callback) -> callback(options.defaultPath))
         atom.commands.dispatch editorPane.getActiveItem().getElement(), 'markdown-preview:save-as-html'
 
       waitsFor ->

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -272,7 +272,9 @@ describe "MarkdownPreviewView", ->
       preview.destroy()
       filePath = atom.project.getDirectories()[0].resolve('subdir/code-block.md')
       preview = new MarkdownPreviewView({filePath})
-      jasmine.attachToDOM(preview.element)
+      # Add to workspace for core:save-as command to be propagated up to the workspace
+      waitsForPromise -> atom.workspace.open(preview)
+      runs -> jasmine.attachToDOM(atom.views.getView(atom.workspace))
 
     it "saves the rendered HTML and opens it", ->
       outputPath = fs.realpathSync(temp.mkdirSync()) + 'output.html'
@@ -310,7 +312,8 @@ describe "MarkdownPreviewView", ->
         preview.renderMarkdown()
 
       runs ->
-        spyOn(atom, 'showSaveDialogSync').andReturn(outputPath)
+        spyOn(preview, 'getSaveDialogOptions').andReturn({defaultPath: outputPath})
+        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake((options, callback) -> callback(options.defaultPath))
         spyOn(preview, 'getDocumentStyleSheets').andReturn(markdownPreviewStyles)
         spyOn(preview, 'getTextEditorStyles').andReturn(atomTextEditorStyles)
         atom.commands.dispatch preview.element, 'core:save-as'

--- a/spec/markdown-preview-view-spec.coffee
+++ b/spec/markdown-preview-view-spec.coffee
@@ -313,7 +313,11 @@ describe "MarkdownPreviewView", ->
 
       runs ->
         spyOn(preview, 'getSaveDialogOptions').andReturn({defaultPath: outputPath})
-        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake((options, callback) -> callback(options.defaultPath))
+        spyOn(atom.applicationDelegate, 'showSaveDialog').andCallFake (options, callback) ->
+          callback?(options.defaultPath)
+          # TODO: When https://github.com/atom/atom/pull/16245 lands remove the return
+          # and the existence check on the callback
+          return options.defaultPath
         spyOn(preview, 'getDocumentStyleSheets').andReturn(markdownPreviewStyles)
         spyOn(preview, 'getTextEditorStyles').andReturn(atomTextEditorStyles)
         atom.commands.dispatch preview.element, 'core:save-as'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Instead of hijacking `core:save-as` and making it do what we want, instead use the public `pane.saveItemAs` method combined with `item.getSaveDialogOptions` to set the filepath we want.  Essentially, it delegates the save dialog and error handling to Atom core and only handles saving the file itself once the filepath has been chosen.

### Alternate Designs

Keep `atom.showSaveDialog[Sync]` in Atom core.

### Benefits

Less custom logic for how to save a file as HTML.

### Possible Drawbacks

I've added a notification to warn when the file can't be saved due to the Markdown still loading.  Unfortunately, it will appear _after_ the save dialog finishes.  I think this is still better than what we had before, which was no feedback.

### Applicable Issues

Refs atom/atom#16245