### PR TITLE
:fire: Change Newline breaks option confusing description

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "breakOnSingleNewline": {
       "type": "boolean",
       "default": false,
-      "description": "In Markdown, a single newline character doesn't cause a line break in the generated HTML. In GitHub Flavored Markdown, that is not true. Enable this config option to insert line breaks in rendered HTML for single newlines in Markdown source."
+      "description": "In Markdown, a single newline character doesn't cause a line break in the generated HTML. In GitHub Flavored Markdown, it does. Enable this option to see a line break in the HTML preview for every single newline in Markdown source."
     },
     "liveUpdate": {
       "type": "boolean",


### PR DESCRIPTION
### Requirements

Keep software (descriptions) as simple as possible.

### Description of the Change

The newline break option is kind of confusing. Let's keep it simple!

### Alternate Designs

Leave the old description.

### Benefits

Simple description = less time to understand the option.

### Possible Drawbacks

None

### Applicable Issues

None
