### PR TITLE
Hide bullet in task lists

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -23,6 +23,12 @@
     position: absolute;
     margin: .25em 0 0 -1.4em;
   }
+
+  // hide bullet for task lists
+  // TODO: Use more specific selector once https://github.com/gjtorikian/task-lists-js/issues/5 gets fixed
+  ul label {
+    vertical-align: top;
+  }
 }
 
 .markdown-spinner {


### PR DESCRIPTION
### Description of the Change

This change adds a `vertical-align` style to the `label` tag. 

### Alternate Designs

Better would be to add a class (https://github.com/atom/markdown-preview/issues/166), but that is blocked by https://github.com/gjtorikian/task-lists-js/issues/5.

### Benefits

When creating checkboxes in markdown, the markdown preview shows the list-style image aligned to the bottom of the list item when it wraps lines.

![image](https://user-images.githubusercontent.com/39604995/40891503-affa2940-6754-11e8-932b-4e4da793c99d.png)

*Note the circle displaying next to "element" and "game" in the preview on the right*

By adding `vertical-align: top` to the label, the circle image is covered by the checkbox, as expected.

### Possible Drawbacks

Could negatively affect other `label` stylings in `ul` elements.

### Applicable Issues

- This PR got moved from https://github.com/atom/one-dark-ui/pull/264
- Kinda "fixes" https://github.com/atom/markdown-preview/issues/166.
