### PR TITLE
Force user-select to auto in atom-text-editor elements within preview

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -16,6 +16,7 @@
         visibility: visible;
       }
     }
+    user-select: auto;
   }
 
   // move task list checkboxes


### PR DESCRIPTION
https://github.com/atom/atom/pull/17985 turns off `user-select` on `<atom-text-editor>`s by default. This is normally what we want (since the editor typically manages its own selection), but not for markdown-preview, since here we rely on native selection for pasteboard interaction.