### PR TITLE
Stop using roaster for rendering markdown

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -178,7 +178,7 @@ module.exports = {
     })
   },
 
-  copyHTML () {
+  async copyHTML () {
     const editor = atom.workspace.getActiveTextEditor()
     if (editor == null) {
       return
@@ -188,19 +188,13 @@ module.exports = {
       renderer = require('./renderer')
     }
     const text = editor.getSelectedText() || editor.getText()
-    return new Promise(function (resolve) {
-      renderer.toHTML(text, editor.getPath(), editor.getGrammar(), function (
-        error,
-        html
-      ) {
-        if (error) {
-          console.warn('Copying Markdown as HTML failed', error)
-        } else {
-          atom.clipboard.write(html)
-          resolve()
-        }
-      })
-    })
+    const html = await renderer.toHTML(
+      text,
+      editor.getPath(),
+      editor.getGrammar()
+    )
+
+    atom.clipboard.write(html)
   },
 
   saveAsHTML () {

--- a/lib/markdown-preview-view.js
+++ b/lib/markdown-preview-view.js
@@ -287,40 +287,35 @@ module.exports = class MarkdownPreviewView {
     }
   }
 
-  getHTML (callback) {
-    return this.getMarkdownSource().then(source => {
-      if (source == null) {
-        return
-      }
+  async getHTML () {
+    const source = await this.getMarkdownSource()
 
-      return renderer.toHTML(
-        source,
-        this.getPath(),
-        this.getGrammar(),
-        callback
-      )
-    })
+    if (source == null) {
+      return
+    }
+
+    return renderer.toHTML(source, this.getPath(), this.getGrammar())
   }
 
-  renderMarkdownText (text) {
+  async renderMarkdownText (text) {
     const { scrollTop } = this.element
-    return renderer.toDOMFragment(
-      text,
-      this.getPath(),
-      this.getGrammar(),
-      (error, domFragment) => {
-        if (error) {
-          this.showError(error)
-        } else {
-          this.loading = false
-          this.loaded = true
-          this.element.textContent = ''
-          this.element.appendChild(domFragment)
-          this.emitter.emit('did-change-markdown')
-          this.element.scrollTop = scrollTop
-        }
-      }
-    )
+
+    try {
+      const domFragment = await renderer.toDOMFragment(
+        text,
+        this.getPath(),
+        this.getGrammar()
+      )
+
+      this.loading = false
+      this.loaded = true
+      this.element.textContent = ''
+      this.element.appendChild(domFragment)
+      this.emitter.emit('did-change-markdown')
+      this.element.scrollTop = scrollTop
+    } catch (error) {
+      this.showError(error)
+    }
   }
 
   getTitle () {
@@ -439,7 +434,7 @@ module.exports = class MarkdownPreviewView {
     selection.addRange(range)
   }
 
-  copyToClipboard () {
+  async copyToClipboard () {
     if (this.loading) {
       return
     }
@@ -456,16 +451,16 @@ module.exports = class MarkdownPreviewView {
     ) {
       atom.clipboard.write(selectedText)
     } else {
-      return this.getHTML(function (error, html) {
-        if (error != null) {
-          atom.notifications.addError('Copying Markdown as HTML failed', {
-            dismissable: true,
-            detail: error.message
-          })
-        } else {
-          atom.clipboard.write(html)
-        }
-      })
+      try {
+        const html = await this.getHTML()
+
+        atom.clipboard.write(html)
+      } catch (error) {
+        atom.notifications.addError('Copying Markdown as HTML failed', {
+          dismissable: true,
+          detail: error.message
+        })
+      }
     }
   }
 
@@ -484,7 +479,7 @@ module.exports = class MarkdownPreviewView {
     return { defaultPath }
   }
 
-  saveAs (htmlFilePath) {
+  async saveAs (htmlFilePath) {
     if (this.loading) {
       atom.notifications.addWarning(
         'Please wait until the Markdown Preview has finished loading before saving'
@@ -498,13 +493,10 @@ module.exports = class MarkdownPreviewView {
       title = path.parse(filePath).name
     }
 
-    return new Promise((resolve, reject) => {
-      return this.getHTML((error, htmlBody) => {
-        if (error != null) {
-          throw error
-        } else {
-          const html =
-            `\
+    const htmlBody = await this.getHTML()
+
+    const html =
+      `\
 <!DOCTYPE html>
 <html>
   <head>
@@ -515,10 +507,7 @@ module.exports = class MarkdownPreviewView {
   <body class='markdown-preview' data-use-github-style>${htmlBody}</body>
 </html>` + '\n' // Ensure trailing newline
 
-          fs.writeFileSync(htmlFilePath, html)
-          return atom.workspace.open(htmlFilePath).then(resolve)
-        }
-      })
-    })
+    fs.writeFileSync(htmlFilePath, html)
+    return atom.workspace.open(htmlFilePath)
   }
 }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -5,13 +5,17 @@ const emoji = require('emoji-images')
 const fs = require('fs-plus')
 let marked = null // Defer until used
 let renderer = null
+let cheerio = null
 const yamlFrontMatter = require('yaml-front-matter')
 
 const { scopeForFenceName } = require('./extension-helper')
 const { resourcePath } = atom.getLoadSettings()
 const packagePath = path.dirname(__dirname)
 
-const emojiFolder = path.join(path.dirname(require.resolve('emoji-images') ), "pngs")
+const emojiFolder = path.join(
+  path.dirname(require.resolve('emoji-images')),
+  'pngs'
+)
 
 exports.toDOMFragment = async function (text, filePath, grammar, callback) {
   if (text == null) {
@@ -46,6 +50,7 @@ exports.toHTML = async function (text, filePath, grammar) {
 
 var render = function (text, filePath) {
   if (marked == null) {
+    cheerio = require('cheerio')
     marked = require('marked')
     renderer = new marked.Renderer()
     renderer.listitem = function (text, isTask) {
@@ -64,7 +69,17 @@ var render = function (text, filePath) {
   const { __content, ...vars } = yamlFrontMatter.loadFront(text)
 
   let html = marked(renderYamlTable(vars) + __content)
-  html = emoji(html, emojiFolder, 20)
+
+  // emoji-images is too aggressive, so replace images in monospace tags with the actual emoji text.
+  const $ = cheerio.load(emoji(html, emojiFolder, 20))
+  $('pre img').each((index, element) =>
+    $(element).replaceWith($(element).attr('title'))
+  )
+  $('code img').each((index, element) =>
+    $(element).replaceWith($(element).attr('title'))
+  )
+
+  html = $.html()
 
   html = createDOMPurify().sanitize(html, {
     ALLOW_UNKNOWN_PROTOCOLS: atom.config.get(

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,7 @@
 const { TextEditor } = require('atom')
 const path = require('path')
 const createDOMPurify = require('dompurify')
+const emoji = require('emoji-images')
 const fs = require('fs-plus')
 let marked = null // Defer until used
 let renderer = null
@@ -9,6 +10,8 @@ const yamlFrontMatter = require('yaml-front-matter')
 const { scopeForFenceName } = require('./extension-helper')
 const { resourcePath } = atom.getLoadSettings()
 const packagePath = path.dirname(__dirname)
+
+const emojiFolder = path.join(path.dirname(require.resolve('emoji-images') ), "pngs")
 
 exports.toDOMFragment = async function (text, filePath, grammar, callback) {
   if (text == null) {
@@ -59,7 +62,9 @@ var render = function (text, filePath) {
   })
 
   const { __content, ...vars } = yamlFrontMatter.loadFront(text)
+
   let html = marked(renderYamlTable(vars) + __content)
+  html = emoji(html, emojiFolder, 20)
 
   html = createDOMPurify().sanitize(html, {
     ALLOW_UNKNOWN_PROTOCOLS: atom.config.get(

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -150,7 +150,8 @@ var highlightCodeBlocks = function (domFragment, grammar, editorCallback) {
         : preElement
     const className = codeBlock.getAttribute('class')
     const fenceName =
-      className != null ? className.replace(/^lang-/, '') : defaultLanguage
+      className != null ? className.replace(/^language-/, '') : defaultLanguage
+
     const editor = new TextEditor({
       readonly: true,
       keyboardInputEnabled: false

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -3,6 +3,7 @@ const path = require('path')
 const createDOMPurify = require('dompurify')
 const fs = require('fs-plus')
 let marked = null // Defer until used
+let renderer = null
 const yamlFrontMatter = require('yaml-front-matter')
 
 const { scopeForFenceName } = require('./extension-helper')
@@ -43,11 +44,18 @@ exports.toHTML = async function (text, filePath, grammar) {
 var render = function (text, filePath) {
   if (marked == null) {
     marked = require('marked')
+    renderer = new marked.Renderer()
+    renderer.listitem = function (text, isTask) {
+      const listAttributes = isTask ? ' class="task-list-item"' : ''
+
+      return `<li ${listAttributes}>${text}</li>\n`
+    }
   }
 
   marked.setOptions({
     sanitize: false,
-    breaks: atom.config.get('markdown-preview.breakOnSingleNewline')
+    breaks: atom.config.get('markdown-preview.breakOnSingleNewline'),
+    renderer
   })
 
   const { __content, ...vars } = yamlFrontMatter.loadFront(text)

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -8,49 +8,38 @@ const { scopeForFenceName } = require('./extension-helper')
 const { resourcePath } = atom.getLoadSettings()
 const packagePath = path.dirname(__dirname)
 
-exports.toDOMFragment = function (text, filePath, grammar, callback) {
+exports.toDOMFragment = async function (text, filePath, grammar, callback) {
   if (text == null) {
     text = ''
   }
 
-  render(text, filePath, function (error, domFragment) {
-    if (error != null) {
-      return callback(error)
-    }
-    highlightCodeBlocks(
-      domFragment,
-      grammar,
-      makeAtomEditorNonInteractive
-    ).then(() => callback(null, domFragment))
-  })
+  const domFragment = render(text, filePath)
+
+  await highlightCodeBlocks(domFragment, grammar, makeAtomEditorNonInteractive)
+
+  return domFragment
 }
 
-exports.toHTML = function (text, filePath, grammar, callback) {
+exports.toHTML = async function (text, filePath, grammar) {
   if (text == null) {
     text = ''
   }
 
-  return render(text, filePath, function (error, domFragment) {
-    if (error != null) {
-      return callback(error)
-    }
+  const domFragment = render(text, filePath)
+  const div = document.createElement('div')
 
-    const div = document.createElement('div')
-    div.appendChild(domFragment)
-    document.body.appendChild(div)
+  div.appendChild(domFragment)
+  document.body.appendChild(div)
 
-    return highlightCodeBlocks(
-      div,
-      grammar,
-      convertAtomEditorToStandardElement
-    ).then(function () {
-      callback(null, div.innerHTML)
-      return div.remove()
-    })
-  })
+  await highlightCodeBlocks(div, grammar, convertAtomEditorToStandardElement)
+
+  const result = div.innerHTML
+  div.remove()
+
+  return result
 }
 
-var render = function (text, filePath, callback) {
+var render = function (text, filePath) {
   if (marked == null) {
     marked = require('marked')
   }
@@ -60,13 +49,7 @@ var render = function (text, filePath, callback) {
     breaks: atom.config.get('markdown-preview.breakOnSingleNewline')
   })
 
-  let html
-
-  try {
-    html = marked(text)
-  } catch (error) {
-    return callback(error)
-  }
+  let html = marked(text)
 
   html = createDOMPurify().sanitize(html, {
     ALLOW_UNKNOWN_PROTOCOLS: atom.config.get(
@@ -79,7 +62,8 @@ var render = function (text, filePath, callback) {
   const fragment = template.content.cloneNode(true)
 
   resolveImagePaths(fragment, filePath)
-  callback(null, fragment)
+
+  return fragment
 }
 
 var resolveImagePaths = function (element, filePath) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -3,6 +3,7 @@ const path = require('path')
 const createDOMPurify = require('dompurify')
 const fs = require('fs-plus')
 let marked = null // Defer until used
+const yamlFrontMatter = require('yaml-front-matter')
 
 const { scopeForFenceName } = require('./extension-helper')
 const { resourcePath } = atom.getLoadSettings()
@@ -49,7 +50,8 @@ var render = function (text, filePath) {
     breaks: atom.config.get('markdown-preview.breakOnSingleNewline')
   })
 
-  let html = marked(text)
+  const { __content, ...vars } = yamlFrontMatter.loadFront(text)
+  let html = marked(renderYamlTable(vars) + __content)
 
   html = createDOMPurify().sanitize(html, {
     ALLOW_UNKNOWN_PROTOCOLS: atom.config.get(
@@ -64,6 +66,24 @@ var render = function (text, filePath) {
   resolveImagePaths(fragment, filePath)
 
   return fragment
+}
+
+function renderYamlTable (variables) {
+  const entries = Object.entries(variables)
+
+  if (!entries.length) {
+    return ''
+  }
+
+  const markdownRows = [
+    entries.map(entry => entry[0]),
+    entries.map(entry => '--'),
+    entries.map(entry => entry[1])
+  ]
+
+  return (
+    markdownRows.map(row => '| ' + row.join(' | ') + ' |').join('\n') + '\n'
+  )
 }
 
 var resolveImagePaths = function (element, filePath) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -60,10 +60,6 @@ var render = function (text, filePath, callback) {
     breaks: atom.config.get('markdown-preview.breakOnSingleNewline')
   })
 
-  // Remove the <!doctype> since otherwise marked will escape it
-  // https://github.com/chjj/marked/issues/354
-  text = text.replace(/^\s*<!doctype(\s+.*)?>\s*/i, '')
-
   let html
 
   try {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,7 +2,8 @@ const { TextEditor } = require('atom')
 const path = require('path')
 const createDOMPurify = require('dompurify')
 const fs = require('fs-plus')
-let roaster = null // Defer until used
+let marked = null // Defer until used
+
 const { scopeForFenceName } = require('./extension-helper')
 const { resourcePath } = atom.getLoadSettings()
 const packagePath = path.dirname(__dirname)
@@ -50,36 +51,39 @@ exports.toHTML = function (text, filePath, grammar, callback) {
 }
 
 var render = function (text, filePath, callback) {
-  if (roaster == null) {
-    roaster = require('roaster')
+  if (marked == null) {
+    marked = require('marked')
   }
-  const options = {
+
+  marked.setOptions({
     sanitize: false,
     breaks: atom.config.get('markdown-preview.breakOnSingleNewline')
-  }
+  })
 
   // Remove the <!doctype> since otherwise marked will escape it
   // https://github.com/chjj/marked/issues/354
   text = text.replace(/^\s*<!doctype(\s+.*)?>\s*/i, '')
 
-  return roaster(text, options, function (error, html) {
-    if (error != null) {
-      return callback(error)
-    }
+  let html
 
-    html = createDOMPurify().sanitize(html, {
-      ALLOW_UNKNOWN_PROTOCOLS: atom.config.get(
-        'markdown-preview.allowUnsafeProtocols'
-      )
-    })
+  try {
+    html = marked(text)
+  } catch (error) {
+    return callback(error)
+  }
 
-    const template = document.createElement('template')
-    template.innerHTML = html.trim()
-    const fragment = template.content.cloneNode(true)
-
-    resolveImagePaths(fragment, filePath)
-    return callback(null, fragment)
+  html = createDOMPurify().sanitize(html, {
+    ALLOW_UNKNOWN_PROTOCOLS: atom.config.get(
+      'markdown-preview.allowUnsafeProtocols'
+    )
   })
+
+  const template = document.createElement('template')
+  template.innerHTML = html.trim()
+  const fragment = template.content.cloneNode(true)
+
+  resolveImagePaths(fragment, filePath)
+  callback(null, fragment)
 }
 
 var resolveImagePaths = function (element, filePath) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "dompurify": "^1.0.2",
+    "emoji-images": "^0.1.1",
     "fs-plus": "^3.0.0",
     "marked": "^0.6.2",
     "underscore-plus": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "atom": "*"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "dompurify": "^1.0.2",
     "emoji-images": "^0.1.1",
     "fs-plus": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "dompurify": "^1.0.2",
     "fs-plus": "^3.0.0",
-    "roaster": "^1.2.1",
+    "marked": "^0.6.2",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dompurify": "^1.0.2",
     "fs-plus": "^3.0.0",
     "marked": "^0.6.2",
-    "underscore-plus": "^1.0.0"
+    "underscore-plus": "^1.0.0",
+    "yaml-front-matter": "^4.0.0"
   },
   "devDependencies": {
     "coffeelint": "^1.9.7",

--- a/spec/fixtures/subdir/file.markdown
+++ b/spec/fixtures/subdir/file.markdown
@@ -1,3 +1,10 @@
+---
+variable1: value1
+array:
+  - foo
+  - bar
+---
+
 ## File.markdown
 
 :cool:

--- a/spec/markdown-preview-spec.js
+++ b/spec/markdown-preview-spec.js
@@ -649,10 +649,10 @@ var x = y;
       runs(() =>
         expect(preview.element.innerHTML).toBe(`\
 <p>hello</p>
-<p></p>
-<p>
+
+
 <img>
-world</p>\
+world\
 `)
       )
     })

--- a/spec/markdown-preview-spec.js
+++ b/spec/markdown-preview-spec.js
@@ -657,7 +657,7 @@ world\
       )
     })
 
-    it('remove the first <!doctype> tag at the beginning of the file', function () {
+    it('remove any <!doctype> tag on markdown files', function () {
       waitsForPromise(() => atom.workspace.open('subdir/doctype-tag.md'))
       runs(() =>
         atom.commands.dispatch(
@@ -670,7 +670,7 @@ world\
       runs(() =>
         expect(preview.element.innerHTML).toBe(`\
 <p>content
-&lt;!doctype html&gt;</p>\
+</p>\
 `)
       )
     })

--- a/spec/markdown-preview-view-spec.js
+++ b/spec/markdown-preview-view-spec.js
@@ -327,6 +327,27 @@ end\
     })
   })
 
+  describe('yaml front matter', function () {
+    it('creates a table with the YAML variables', function () {
+      atom.config.set('markdown-preview.breakOnSingleNewline', true)
+
+      waitsForPromise(() => preview.renderMarkdown())
+
+      runs(() => {
+        expect(
+          [...preview.element.querySelectorAll('table th')].map(
+            el => el.textContent
+          )
+        ).toEqual(['variable1', 'array'])
+        expect(
+          [...preview.element.querySelectorAll('table td')].map(
+            el => el.textContent
+          )
+        ).toEqual(['value1', 'foo,bar'])
+      })
+    })
+  })
+
   describe('text selections', function () {
     it('adds the `has-selection` class to the preview depending on if there is a text selection', function () {
       expect(preview.element.classList.contains('has-selection')).toBe(false)

--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -20,15 +20,13 @@
   }
 
   // move task list checkboxes
-  .task-list-item-checkbox {
+  .task-list-item input[type=checkbox] {
     position: absolute;
     margin: .25em 0 0 -1.4em;
   }
 
-  // hide bullet for task lists
-  // TODO: Use more specific selector once https://github.com/gjtorikian/task-lists-js/issues/5 gets fixed
-  ul label {
-    vertical-align: top;
+  .task-list-item {
+    list-style-type: none;
   }
 }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

In order to fix https://github.com/atom/markdown-preview/issues/206, the version of the `marked` package needed to be upgraded. Since this package depended on `roaster`, which is unmaintained and not even recommended to be used by its own creator, I've opted to replace it by directly calling `marked` and implementing in this package the missing functionality.

### Alternate Designs

I could have forked `roaster` (in fact a really old fork of it already exists on the atom org: http://github.com/atom/roaster) and then upgrade `marked` from that fork, but I prefer to avoid having yet another fork and yet another package to maintain.

### Benefits

Fixes https://github.com/atom/markdown-preview/issues/206

### Possible Drawbacks

N/A

### Applicable Issues

https://github.com/atom/markdown-preview/issues/206
