### PR TITLE
Lazy load yaml frontmatter

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -6,7 +6,7 @@ const fs = require('fs-plus')
 let marked = null // Defer until used
 let renderer = null
 let cheerio = null
-const yamlFrontMatter = require('yaml-front-matter')
+let yamlFrontMatter = null
 
 const { scopeForFenceName } = require('./extension-helper')
 const { resourcePath } = atom.getLoadSettings()
@@ -49,9 +49,11 @@ exports.toHTML = async function (text, filePath, grammar) {
 }
 
 var render = function (text, filePath) {
-  if (marked == null) {
-    cheerio = require('cheerio')
+  if (marked == null || yamlFrontMatter == null || cheerio == null) {
     marked = require('marked')
+    yamlFrontMatter = require('yaml-front-matter')
+    cheerio = require('cheerio')
+
     renderer = new marked.Renderer()
     renderer.listitem = function (text, isTask) {
       const listAttributes = isTask ? ' class="task-list-item"' : ''


### PR DESCRIPTION
Without lazy loading this module, tons of new files are added to the startup script (~500 of them) and some of them cause issues when generating it (see https://github.com/atom/electron-link/pull/20#issuecomment-486643317).