### PR TITLE
Fix markdown preview HTML file save with fenced code blocks.

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -186,6 +186,13 @@ var highlightCodeBlocks = function (domFragment, grammar, editorCallback) {
     const fenceName =
       className != null ? className.replace(/^language-/, '') : defaultLanguage
 
+    // Don't proceed with tokenizing if it's plain text. There is no
+    // need and tokenization will not complete. The promise will never
+    // resolve and whatever depends on it (e.g. save file) will fail.
+    if (fenceName == 'text') {
+      continue;
+    }
+
     const editor = new TextEditor({
       readonly: true,
       keyboardInputEnabled: false

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -189,8 +189,8 @@ var highlightCodeBlocks = function (domFragment, grammar, editorCallback) {
     // Don't proceed with tokenizing if it's plain text. There is no
     // need and tokenization will not complete. The promise will never
     // resolve and whatever depends on it (e.g. save file) will fail.
-    if (fenceName == 'text') {
-      continue;
+    if (fenceName === 'text') {
+      continue
     }
 
     const editor = new TextEditor({


### PR DESCRIPTION
# Description of the Change

Fixes issue #552, which is about markdown preview silently failing to "Save As..." when the markdown contains plain text fenced code blocks.

The patch here simply stops attempting to tokenize plain text fenced code blocks for syntax highlighting. It isn't necessary anyway.

You can read about the development of this patch in this comment:

https://github.com/atom/markdown-preview/issues/552#issuecomment-509915012

This explains the code paths taken, and ultimately what the problem is (an unfulfilled promise when attempting to tokenize plain text).

### Alternate Designs

A possible alternative fix might consider why no onDidTokenize callback happens when attempting to tokenize plain text. I don't believe the effects of such a fix would be any different than this patch, as there is no point in attempting to tokenize a plain text block.

### Benefits

Issue #552 is fixed. Plain text (no language) fenced code blocks no longer cause file saves to fail.

### Possible Drawbacks

None that I'm aware of.

### Applicable Issues

Issue 552
